### PR TITLE
Rename HerdMan server process title

### DIFF
--- a/apps/macos/Packages/HerdManCore/Sources/HerdManCore/Server/LocalHerdManServer.swift
+++ b/apps/macos/Packages/HerdManCore/Sources/HerdManCore/Server/LocalHerdManServer.swift
@@ -18,6 +18,11 @@ public struct LocalHerdManServerLaunchRequest: Equatable, Sendable {
     public var environment: [String: String]
 }
 
+struct LocalHerdManServerProcessConfiguration: Equatable {
+    var executableURL: URL
+    var arguments: [String]
+}
+
 @MainActor
 public final class LocalHerdManServer {
     public typealias Launcher = @MainActor (LocalHerdManServerLaunchRequest) throws -> Process
@@ -244,26 +249,41 @@ public final class LocalHerdManServer {
         try logHandle.seekToEnd()
 
         let process = Process()
-        process.executableURL = request.nodeExecutable
-        let nodeArguments = request.nodeExecutable.lastPathComponent == "env" ? ["node"] : []
-        process.arguments = nodeArguments + [
-            request.entrypoint.path,
-            "serve",
-            "--host", request.host,
-            "--port", String(request.port),
-            "--db", request.databasePath,
-            // Network binds require a token from remote clients (loopback is
-            // exempt), and --kind keeps the server identifying as this
-            // machine's local server despite the 0.0.0.0 bind.
-            "--auth", "token",
-            "--kind", "local",
-            "--name", request.name
-        ]
+        let configuration = processConfiguration(for: request)
+        process.executableURL = configuration.executableURL
+        process.arguments = configuration.arguments
         process.environment = request.environment
         process.standardOutput = logHandle
         process.standardError = logHandle
         try process.run()
         return process
+    }
+
+    static func processConfiguration(
+        for request: LocalHerdManServerLaunchRequest
+    ) -> LocalHerdManServerProcessConfiguration {
+        let nodeInvocation = request.nodeExecutable.lastPathComponent == "env"
+            ? "node"
+            : request.nodeExecutable.path
+        return LocalHerdManServerProcessConfiguration(
+            executableURL: URL(fileURLWithPath: "/bin/bash"),
+            arguments: [
+                "-c",
+                "exec -a herdman-server \"$0\" \"$@\"",
+                nodeInvocation,
+                request.entrypoint.path,
+                "serve",
+                "--host", request.host,
+                "--port", String(request.port),
+                "--db", request.databasePath,
+                // Network binds require a token from remote clients (loopback is
+                // exempt), and --kind keeps the server identifying as this
+                // machine's local server despite the 0.0.0.0 bind.
+                "--auth", "token",
+                "--kind", "local",
+                "--name", request.name
+            ]
+        )
     }
 
     public static func defaultEntrypoint() -> URL? {

--- a/apps/macos/Packages/HerdManCore/Tests/HerdManCoreTests/LocalHerdManServerTests.swift
+++ b/apps/macos/Packages/HerdManCore/Tests/HerdManCoreTests/LocalHerdManServerTests.swift
@@ -57,6 +57,52 @@ struct LocalHerdManServerTests {
         #expect(launches.first?.environment["HERDMAN_TEST"] == "1")
     }
 
+    @Test("Launch command names the server process")
+    func launchCommandNamesServerProcess() {
+        let request = LocalHerdManServerLaunchRequest(
+            nodeExecutable: URL(fileURLWithPath: "/opt/homebrew/bin/node"),
+            entrypoint: URL(fileURLWithPath: "/tmp/herdman-server/main.js"),
+            databasePath: "/tmp/herdman.sqlite",
+            logURL: URL(fileURLWithPath: "/tmp/herdman-server.log"),
+            host: "0.0.0.0",
+            port: 49362,
+            name: "Test Mac",
+            environment: [:]
+        )
+
+        let configuration = LocalHerdManServer.processConfiguration(for: request)
+
+        #expect(configuration.executableURL.path == "/bin/bash")
+        #expect(Array(configuration.arguments.prefix(3)) == [
+            "-c",
+            "exec -a herdman-server \"$0\" \"$@\"",
+            "/opt/homebrew/bin/node"
+        ])
+        #expect(Array(configuration.arguments.dropFirst(3).prefix(2)) == [
+            "/tmp/herdman-server/main.js",
+            "serve"
+        ])
+    }
+
+    @Test("Launch command preserves PATH lookup when Node falls back to env")
+    func launchCommandUsesPathLookupForEnvFallback() {
+        let request = LocalHerdManServerLaunchRequest(
+            nodeExecutable: URL(fileURLWithPath: "/usr/bin/env"),
+            entrypoint: URL(fileURLWithPath: "/tmp/herdman-server/main.js"),
+            databasePath: "/tmp/herdman.sqlite",
+            logURL: URL(fileURLWithPath: "/tmp/herdman-server.log"),
+            host: "0.0.0.0",
+            port: 49362,
+            name: "Test Mac",
+            environment: ["PATH": "/opt/homebrew/bin:/usr/bin"]
+        )
+
+        let configuration = LocalHerdManServer.processConfiguration(for: request)
+
+        #expect(configuration.executableURL.path == "/bin/bash")
+        #expect(configuration.arguments.dropFirst(2).first == "node")
+    }
+
     @Test("Reports unavailable when no server entrypoint can be found")
     func missingEntrypoint() async {
         let client = FakeLocalServerClient(healthResults: [.failure(TestError())])

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -17,6 +17,10 @@ import {
   type HerdManServerUpdater
 } from "./server.js"
 
+const SERVER_PROCESS_TITLE = "herdman-server"
+
+process.title = SERVER_PROCESS_TITLE
+
 const parseArgs = (args: ReadonlyArray<string>): Record<string, string> => {
   const parsed: Record<string, string> = {}
   for (let index = 0; index < args.length; index += 1) {
@@ -161,8 +165,16 @@ const makeSelfUpdater = (options: {
     // port, then execs the new runtime with the same serve arguments.
     console.log(`Restarting into HerdMan server ${info.latestVersion}`)
     const handoff = spawn(
-      "/bin/sh",
-      ["-c", 'sleep 1; exec "$@"', "sh", nodeBinary, entrypoint, "serve", ...options.serveArgs],
+      "/bin/bash",
+      [
+        "-c",
+        `sleep 1; exec -a ${SERVER_PROCESS_TITLE} "$@"`,
+        "bash",
+        nodeBinary,
+        entrypoint,
+        "serve",
+        ...options.serveArgs
+      ],
       { detached: true, stdio: "ignore" }
     )
     handoff.unref()

--- a/scripts/release/build-server-runtime.sh
+++ b/scripts/release/build-server-runtime.sh
@@ -144,7 +144,7 @@ node_bin="${HERDMAN_NODE:-}"
 if [[ -z "$node_bin" && -x "$root/bin/node" ]]; then
   node_bin="$root/bin/node"
 fi
-exec "${node_bin:-node}" "$root/main.js" "$@"
+exec -a herdman-server "${node_bin:-node}" "$root/main.js" "$@"
 EOF
 
 cat > "$runtime_dir/bin/herdman-terminal-proxy" <<'EOF'
@@ -155,7 +155,7 @@ node_bin="${HERDMAN_NODE:-}"
 if [[ -z "$node_bin" && -x "$root/bin/node" ]]; then
   node_bin="$root/bin/node"
 fi
-exec "${node_bin:-node}" "$root/terminal-proxy.js" "$@"
+exec -a herdman-terminal-proxy "${node_bin:-node}" "$root/terminal-proxy.js" "$@"
 EOF
 
 chmod +x "$runtime_dir/bin/herdman-server" "$runtime_dir/bin/herdman-terminal-proxy"


### PR DESCRIPTION
## Summary
- Name the Node-backed HerdMan server process as `herdman-server` with `process.title`.
- Launch app-owned and packaged server runtimes with `exec -a herdman-server` so `ps` presents a useful process name.
- Add focused Swift coverage for the macOS launch command, including the PATH lookup fallback.

Linear: https://linear.app/851/issue/851-2224/rename-node-process-to-something-more-appropriate-maybe-herdman-server

## Before / After
These are real PNG captures generated from actual VM command output. The before capture runs the parent commit server; the after capture runs this branch. The PNGs are hosted on the separate `codex/851-2224-pr-assets` branch, not in this PR diff.

| Before | After |
| --- | --- |
| ![Before actual VM process capture](https://raw.githubusercontent.com/851-labs/herdman/55eb1d9f61ec0fbafd02fb749e638cf84cc75a03/assets/851-2224/before.png) | ![After actual VM process capture](https://raw.githubusercontent.com/851-labs/herdman/55eb1d9f61ec0fbafd02fb749e638cf84cc75a03/assets/851-2224/after.png) |

Note: `ps` now reports the server command as `herdman-server`. macOS `ucomm`/`lsof COMMAND` still show the underlying executable basename `node`, which is expected without replacing the Node binary.

## Verification
- `tart exec herdman-851-2224-rename-node-process zsh -lc 'cd /Users/admin/herdman-dev && bun run --cwd apps/server typecheck'`
- `tart exec herdman-851-2224-rename-node-process zsh -lc 'cd /Users/admin/herdman-dev && swift test --package-path apps/macos/Packages --filter LocalHerdManServer'` - 10 tests passed
- `/Users/alexandru/.codex/skills/herdman-ticket-vm-manager/scripts/verify-in-vm.sh 851-2224-rename-node-process` - server listened on `127.0.0.1:49362`, Xcode build succeeded, and `HerdMan Dev.app` launched
- Extra VM capture confirmed: parent commit showed `3364 node`; current branch showed `3450 herdman-server`
