### PR TITLE
Redesign workspace tabs and splits

### DIFF
--- a/apps/macos/Codevisor/ContentView.swift
+++ b/apps/macos/Codevisor/ContentView.swift
@@ -38,6 +38,7 @@ struct CodevisorApp: App {
             FileCommands()
             MachineCommands(machines: environment.machines)
             TerminalCommands()
+            WorkspaceLayoutCommands()
             ScratchpadCommands()
             DebugOverlayCommands()
             // Provides the Format menu (⌘B/⌘I etc.) for the scratchpad's

--- a/apps/macos/Codevisor/DesignSystem/ChatSessionLeadingIcon.swift
+++ b/apps/macos/Codevisor/DesignSystem/ChatSessionLeadingIcon.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import CodevisorCore
+
+/// The shared chat identity/status slot used by the sidebar and split headers.
+/// Attention states replace the harness icon in the same priority order
+/// everywhere the chat is represented.
+struct ChatSessionLeadingIcon: View {
+    let session: ChatSession
+    let store: SessionStore?
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Group {
+            if store?.hasUnreadError(session) == true {
+                ErrorUnreadBadge(color: theme.statusError)
+            } else if store?.isWaitingOnUser(session) == true {
+                ActionRequiredIndicator(color: theme.statusError)
+            } else if store?.isRunning(session) == true {
+                AgentActivityIndicator()
+            } else if let store, store.unreadCount(session) > 0 {
+                UnreadBadge(color: notificationColor)
+            } else {
+                HarnessIcon(harnessId: session.harnessId, fallbackSymbolName: "bubble.left.fill")
+            }
+        }
+        .frame(width: 18)
+    }
+
+    private var notificationColor: Color {
+        theme.isSystem ? .blue : theme.accent
+    }
+}

--- a/apps/macos/Codevisor/Features/Panes/Pane.swift
+++ b/apps/macos/Codevisor/Features/Panes/Pane.swift
@@ -40,6 +40,10 @@ enum PaneGroupCommand {
     case nextTab
     case newTab
     case selectTab(Int)
+    case split(SplitEdge)
+    case focusSplit(SplitEdge)
+    case previousSplit
+    case nextSplit
     case togglePanel
     case closeTab
 }

--- a/apps/macos/Codevisor/Features/Panes/PaneGroupModel.swift
+++ b/apps/macos/Codevisor/Features/Panes/PaneGroupModel.swift
@@ -63,6 +63,10 @@ final class PaneGroupModel: Identifiable {
     /// root. Wired by the container; nil (previews) leaves spawns on the
     /// anchor session's cwd resolution.
     @ObservationIgnored var defaultSpawnCwd: (() -> String?)?
+    /// Center leaves hand workspace-level tab/split commands to their
+    /// container. Returning true means the command was consumed. Bottom
+    /// panel models leave this nil and retain their local tab behavior.
+    @ObservationIgnored var workspaceCommandHandler: ((PaneGroupCommand) -> Bool)?
     /// Debounces height persistence during drags (state itself updates live).
     @ObservationIgnored private var pendingHeightSave: Task<Void, Never>?
 
@@ -168,10 +172,11 @@ final class PaneGroupModel: Identifiable {
         }
     }
 
-    /// Keyboard shortcuts forwarded from a focused pane: ⌘⌥←/→ navigate
-    /// tabs (wrapping), ⌘T adds a terminal. Focus follows the new selection
-    /// so the keyboard stays in the pane group.
+    /// Keyboard shortcuts forwarded from a focused pane. Center leaves first
+    /// offer them to the workspace container; bottom-panel groups retain
+    /// local tab selection and terminal creation behavior.
     func handleCommand(_ command: PaneGroupCommand) {
+        if workspaceCommandHandler?(command) == true { return }
         switch command {
         case .newTab:
             // ⌘T opens the "New tab" page (Chrome semantics — pick what the
@@ -196,6 +201,8 @@ final class PaneGroupModel: Identifiable {
             guard state.panes.indices.contains(index) else { return }
             select(id: state.panes[index].id)
             DispatchQueue.main.async { [weak self] in self?.focusSelectedPane() }
+        case .split, .focusSplit, .previousSplit, .nextSplit:
+            return
         case .togglePanel:
             requestToggle?()
         case .closeTab:
@@ -260,6 +267,15 @@ final class PaneGroupModel: Identifiable {
     /// Binds a draft chat pane to its just-created session (first send).
     func assignChatSession(paneId: UUID, sessionId: UUID, name: String) {
         state.assignChatSession(paneId: paneId, sessionId: sessionId, name: name)
+        persist()
+    }
+
+    func renamePane(id: UUID, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let index = state.panes.firstIndex(where: { $0.id == id }),
+              state.panes[index].name != trimmed else { return }
+        state.panes[index].name = trimmed
         persist()
     }
 

--- a/apps/macos/Codevisor/Features/Panes/PaneGroupView.swift
+++ b/apps/macos/Codevisor/Features/Panes/PaneGroupView.swift
@@ -834,7 +834,7 @@ private final class TabAppearanceLedger {
     var seeded = false
 }
 
-private struct PaneTab: View {
+struct PaneTab: View {
     @Environment(\.theme) private var theme
     let name: String
     let kind: PaneKind

--- a/apps/macos/Codevisor/Features/Panes/WorkspaceCommands.swift
+++ b/apps/macos/Codevisor/Features/Panes/WorkspaceCommands.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import CodevisorCore
+
+struct WorkspaceLayoutActions: Equatable {
+    let workspaceId: UUID
+    let newTab: @MainActor () -> Void
+    let closeSplit: @MainActor () -> Void
+    let closeTab: @MainActor () -> Void
+    let previousTab: @MainActor () -> Void
+    let nextTab: @MainActor () -> Void
+    let previousSplit: @MainActor () -> Void
+    let nextSplit: @MainActor () -> Void
+    let split: @MainActor (SplitEdge) -> Void
+    let focus: @MainActor (SplitEdge) -> Void
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.workspaceId == rhs.workspaceId
+    }
+}
+
+private struct WorkspaceLayoutActionsKey: FocusedValueKey {
+    typealias Value = WorkspaceLayoutActions
+}
+
+extension FocusedValues {
+    var workspaceLayoutActions: WorkspaceLayoutActions? {
+        get { self[WorkspaceLayoutActionsKey.self] }
+        set { self[WorkspaceLayoutActionsKey.self] = newValue }
+    }
+}
+
+struct WorkspaceLayoutCommands: Commands {
+    @FocusedValue(\.workspaceLayoutActions) private var actions
+
+    var body: some Commands {
+        CommandMenu("Tabs & Splits") {
+            Button("New Tab") { actions?.newTab() }
+                .keyboardShortcut("t", modifiers: .command)
+                .disabled(actions == nil)
+
+            Button("Close Split") { actions?.closeSplit() }
+                .keyboardShortcut("w", modifiers: .command)
+                .disabled(actions == nil)
+            Button("Close Tab") { actions?.closeTab() }
+                .disabled(actions == nil)
+
+            Divider()
+
+            Button("Previous Tab") { actions?.previousTab() }
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+                .disabled(actions == nil)
+            Button("Next Tab") { actions?.nextTab() }
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+                .disabled(actions == nil)
+
+            Divider()
+
+            Button("Previous Split") { actions?.previousSplit() }
+                .keyboardShortcut("[", modifiers: .command)
+                .disabled(actions == nil)
+            Button("Next Split") { actions?.nextSplit() }
+                .keyboardShortcut("]", modifiers: .command)
+                .disabled(actions == nil)
+
+            Divider()
+
+            Button("Split Left") { actions?.split(.leading) }
+                .disabled(actions == nil)
+            Button("Split Right") { actions?.split(.trailing) }
+                .keyboardShortcut("d", modifiers: .command)
+                .disabled(actions == nil)
+            Button("Split Up") { actions?.split(.top) }
+                .disabled(actions == nil)
+            Button("Split Down") { actions?.split(.bottom) }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+                .disabled(actions == nil)
+
+            Divider()
+
+            Button("Focus Split Left") { actions?.focus(.leading) }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                .disabled(actions == nil)
+            Button("Focus Split Right") { actions?.focus(.trailing) }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                .disabled(actions == nil)
+            Button("Focus Split Above") { actions?.focus(.top) }
+                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                .disabled(actions == nil)
+            Button("Focus Split Below") { actions?.focus(.bottom) }
+                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                .disabled(actions == nil)
+        }
+    }
+}

--- a/apps/macos/Codevisor/Features/Panes/WorkspaceSplitDrag.swift
+++ b/apps/macos/Codevisor/Features/Panes/WorkspaceSplitDrag.swift
@@ -1,0 +1,270 @@
+//  Drag-to-rearrange for one workspace tab's split leaves. Each mounted
+//  leaf reports its global frame; while a header drag is active the nearest
+//  valid edge of the hovered leaf becomes the drop target.
+
+import AppKit
+import SwiftUI
+import CodevisorCore
+
+struct WorkspaceSplitDropResolution: Equatable {
+    let targetLeafId: UUID
+    let edge: SplitEdge
+}
+
+@MainActor
+@Observable
+final class WorkspaceSplitDragCoordinator {
+    struct ActiveDrag {
+        let sourceLeafId: UUID
+        let name: String
+        let kind: PaneKind
+        let isAgentOwned: Bool
+        var location: CGPoint
+        var resolution: WorkspaceSplitDropResolution?
+    }
+
+    static let minChildWidth: CGFloat = 320
+    static let minChildHeight: CGFloat = 280
+
+    private struct OwnedFrame {
+        let owner: UUID
+        var frame: CGRect
+    }
+
+    private(set) var active: ActiveDrag?
+    @ObservationIgnored private var leafFrames: [UUID: OwnedFrame] = [:]
+    /// Container-owned validation against the candidate tree after the
+    /// source leaf has been removed and reinserted.
+    @ObservationIgnored var canResolve: ((UUID, WorkspaceSplitDropResolution, CGSize) -> Bool)?
+    @ObservationIgnored var onResolve: ((UUID, WorkspaceSplitDropResolution) -> Void)?
+
+    func registerLeaf(owner: UUID, leafId: UUID) {
+        if leafFrames[leafId]?.owner != owner {
+            leafFrames[leafId] = OwnedFrame(owner: owner, frame: .zero)
+        }
+    }
+
+    func updateLeafFrame(_ frame: CGRect, owner: UUID, leafId: UUID) {
+        guard leafFrames[leafId]?.owner == owner else { return }
+        leafFrames[leafId]?.frame = frame
+        refreshResolution()
+    }
+
+    func unregisterLeaf(owner: UUID, leafId: UUID) {
+        guard leafFrames[leafId]?.owner == owner else { return }
+        leafFrames[leafId] = nil
+        refreshResolution()
+    }
+
+    func dragUpdated(
+        sourceLeafId: UUID,
+        name: String,
+        kind: PaneKind,
+        isAgentOwned: Bool,
+        location: CGPoint
+    ) {
+        active = ActiveDrag(
+            sourceLeafId: sourceLeafId,
+            name: name,
+            kind: kind,
+            isAgentOwned: isAgentOwned,
+            location: location,
+            resolution: resolve(location, sourceLeafId: sourceLeafId)
+        )
+    }
+
+    @discardableResult
+    func dragEnded() -> Bool {
+        defer { active = nil }
+        guard let active, let resolution = active.resolution else { return false }
+        onResolve?(active.sourceLeafId, resolution)
+        return true
+    }
+
+    func dragCancelled() {
+        active = nil
+    }
+
+    func previewEdge(for leafId: UUID) -> SplitEdge? {
+        guard let resolution = active?.resolution,
+              resolution.targetLeafId == leafId else { return nil }
+        return resolution.edge
+    }
+
+    private func refreshResolution() {
+        guard var active else { return }
+        active.resolution = resolve(active.location, sourceLeafId: active.sourceLeafId)
+        self.active = active
+    }
+
+    private func resolve(_ location: CGPoint, sourceLeafId: UUID) -> WorkspaceSplitDropResolution? {
+        let target = leafFrames
+            .filter { leafId, registration in
+                leafId != sourceLeafId
+                    && registration.frame.width > 0
+                    && registration.frame.height > 0
+                    && registration.frame.contains(location)
+            }
+            // Frames should not overlap, but choosing the smallest makes a
+            // stale ancestor-sized registration harmless during remounts.
+            .min { lhs, rhs in
+                lhs.value.frame.width * lhs.value.frame.height
+                    < rhs.value.frame.width * rhs.value.frame.height
+            }
+
+        guard let (leafId, registration) = target else { return nil }
+        let canvas = leafFrames.values
+            .map(\.frame)
+            .filter { $0.width > 0 && $0.height > 0 }
+            .reduce(CGRect.null) { $0.union($1) }
+
+        for edge in candidateEdges(in: registration.frame, location: location) {
+            let resolution = WorkspaceSplitDropResolution(targetLeafId: leafId, edge: edge)
+            if let canResolve {
+                if canResolve(sourceLeafId, resolution, canvas.size) { return resolution }
+            } else if targetCanSplit(registration.frame, on: edge) {
+                return resolution
+            }
+        }
+        return nil
+    }
+
+    private func candidateEdges(in frame: CGRect, location: CGPoint) -> [SplitEdge] {
+        let u = Double((location.x - frame.minX) / frame.width)
+        let v = Double((location.y - frame.minY) / frame.height)
+        let candidates: [(edge: SplitEdge, distance: Double)] = [
+            (edge: .leading, distance: u),
+            (edge: .trailing, distance: 1 - u),
+            (edge: .top, distance: v),
+            (edge: .bottom, distance: 1 - v)
+        ]
+        return candidates
+            .sorted { $0.distance < $1.distance }
+            .map(\.edge)
+    }
+
+    private func targetCanSplit(_ frame: CGRect, on edge: SplitEdge) -> Bool {
+        switch edge {
+        case .leading, .trailing:
+            return (frame.width - 1) / 2 >= Self.minChildWidth
+        case .top, .bottom:
+            return (frame.height - 1) / 2 >= Self.minChildHeight
+        }
+    }
+}
+
+struct WorkspaceSplitDropZoneModifier: ViewModifier {
+    let coordinator: WorkspaceSplitDragCoordinator?
+    let leafId: UUID
+
+    @State private var measuredFrame: CGRect = .zero
+    @State private var geometryOwner = UUID()
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGRect.self) { proxy in
+                proxy.frame(in: .global)
+            } action: { frame in
+                measuredFrame = frame
+                coordinator?.updateLeafFrame(frame, owner: geometryOwner, leafId: leafId)
+            }
+            .onChange(of: coordinator?.active?.sourceLeafId) { _, active in
+                guard active != nil, measuredFrame != .zero else { return }
+                coordinator?.registerLeaf(owner: geometryOwner, leafId: leafId)
+                coordinator?.updateLeafFrame(measuredFrame, owner: geometryOwner, leafId: leafId)
+            }
+            .onAppear {
+                coordinator?.registerLeaf(owner: geometryOwner, leafId: leafId)
+                if measuredFrame != .zero {
+                    coordinator?.updateLeafFrame(measuredFrame, owner: geometryOwner, leafId: leafId)
+                }
+            }
+            .onDisappear {
+                coordinator?.unregisterLeaf(owner: geometryOwner, leafId: leafId)
+            }
+            .overlay {
+                if let edge = coordinator?.previewEdge(for: leafId) {
+                    WorkspaceSplitDropPreview(edge: edge)
+                        .allowsHitTesting(false)
+                }
+            }
+    }
+}
+
+extension View {
+    func workspaceSplitDropZone(
+        _ coordinator: WorkspaceSplitDragCoordinator?,
+        leafId: UUID
+    ) -> some View {
+        modifier(WorkspaceSplitDropZoneModifier(coordinator: coordinator, leafId: leafId))
+    }
+}
+
+private struct WorkspaceSplitDropPreview: View {
+    @Environment(\.theme) private var theme
+    let edge: SplitEdge
+
+    var body: some View {
+        GeometryReader { geometry in
+            let rect = regionRect(in: geometry.size)
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(theme.accent.opacity(0.12))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(theme.accent.opacity(0.4))
+                }
+                .frame(width: rect.width, height: rect.height)
+                .offset(x: rect.minX, y: rect.minY)
+                .animation(.snappy(duration: 0.16), value: edge)
+        }
+        .padding(2)
+    }
+
+    private func regionRect(in size: CGSize) -> CGRect {
+        switch edge {
+        case .leading:
+            CGRect(x: 0, y: 0, width: size.width / 2, height: size.height)
+        case .trailing:
+            CGRect(x: size.width / 2, y: 0, width: size.width / 2, height: size.height)
+        case .top:
+            CGRect(x: 0, y: 0, width: size.width, height: size.height / 2)
+        case .bottom:
+            CGRect(x: 0, y: size.height / 2, width: size.width, height: size.height / 2)
+        }
+    }
+}
+
+struct WorkspaceSplitDragGhost: View {
+    @Environment(\.theme) private var theme
+    let name: String
+    let kind: PaneKind
+    let isAgentOwned: Bool
+
+    private var iconName: String {
+        switch kind {
+        case .chat: "text.bubble"
+        case .terminal: isAgentOwned ? "server.rack" : "terminal"
+        case .newTab: "square.dashed"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: iconName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.textSecondary)
+            Text(name)
+                .font(.system(size: 11.5, weight: .medium))
+                .lineLimit(1)
+                .foregroundStyle(theme.textPrimary)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(theme.popoverBackground, in: RoundedRectangle(cornerRadius: 6))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .strokeBorder(theme.separator)
+        }
+        .shadow(color: .black.opacity(0.3), radius: 6, y: 2)
+    }
+}

--- a/apps/macos/Codevisor/Features/Panes/WorkspaceSplitView.swift
+++ b/apps/macos/Codevisor/Features/Panes/WorkspaceSplitView.swift
@@ -16,6 +16,7 @@ struct WorkspaceSplitView: View {
     let groupModel: (UUID) -> PaneGroupModel
     let paneTitle: (PaneDescriptorState) -> String
     let sessionStore: SessionStore?
+    let dragCoordinator: WorkspaceSplitDragCoordinator?
     let onSplitLeaf: (UUID, SplitEdge) -> Void
     let onRenameLeaf: (UUID, String) -> Void
     let onCloseLeaf: (UUID) -> Void
@@ -33,12 +34,31 @@ struct WorkspaceSplitView: View {
             groupModel: groupModel,
             paneTitle: paneTitle,
             sessionStore: sessionStore,
+            dragCoordinator: dragCoordinator,
             onSplitLeaf: onSplitLeaf,
             onRenameLeaf: onRenameLeaf,
             onCloseLeaf: onCloseLeaf,
             replaceNode: onTreeChanged,
             replaceLiveNode: { onLiveTreeChanged?($0) }
         )
+        .overlay { dragGhostOverlay }
+    }
+
+    private var dragGhostOverlay: some View {
+        GeometryReader { proxy in
+            if let drag = dragCoordinator?.active {
+                WorkspaceSplitDragGhost(
+                    name: drag.name,
+                    kind: drag.kind,
+                    isAgentOwned: drag.isAgentOwned
+                )
+                .position(
+                    x: drag.location.x - proxy.frame(in: .global).minX,
+                    y: drag.location.y - proxy.frame(in: .global).minY
+                )
+            }
+        }
+        .allowsHitTesting(false)
     }
 }
 
@@ -49,6 +69,7 @@ private struct SplitNodeView: View {
     let groupModel: (UUID) -> PaneGroupModel
     let paneTitle: (PaneDescriptorState) -> String
     let sessionStore: SessionStore?
+    let dragCoordinator: WorkspaceSplitDragCoordinator?
     let onSplitLeaf: (UUID, SplitEdge) -> Void
     let onRenameLeaf: (UUID, String) -> Void
     let onCloseLeaf: (UUID) -> Void
@@ -66,6 +87,7 @@ private struct SplitNodeView: View {
                 groupModel: groupModel,
                 paneTitle: paneTitle,
                 sessionStore: sessionStore,
+                dragCoordinator: dragCoordinator,
                 onSplit: { edge in onSplitLeaf(id, edge) },
                 onRename: { name in onRenameLeaf(id, name) },
                 onClose: { onCloseLeaf(id) }
@@ -79,6 +101,7 @@ private struct SplitNodeView: View {
                 groupModel: groupModel,
                 paneTitle: paneTitle,
                 sessionStore: sessionStore,
+                dragCoordinator: dragCoordinator,
                 onSplitLeaf: onSplitLeaf,
                 onRenameLeaf: onRenameLeaf,
                 onCloseLeaf: onCloseLeaf,
@@ -97,6 +120,7 @@ private struct SplitLeafView: View {
     let groupModel: (UUID) -> PaneGroupModel
     let paneTitle: (PaneDescriptorState) -> String
     let sessionStore: SessionStore?
+    let dragCoordinator: WorkspaceSplitDragCoordinator?
     let onSplit: (SplitEdge) -> Void
     let onRename: (String) -> Void
     let onClose: () -> Void
@@ -110,6 +134,8 @@ private struct SplitLeafView: View {
                 pane: model.state.selectedPane,
                 title: paneTitle,
                 sessionStore: sessionStore,
+                leafId: leafId,
+                dragCoordinator: dragCoordinator,
                 onActivate: { model.onActivated?() },
                 onSplit: onSplit,
                 onRename: onRename,
@@ -125,6 +151,7 @@ private struct SplitLeafView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .overlay { inactiveSplitTint }
+        .workspaceSplitDropZone(dragCoordinator, leafId: leafId)
     }
 
     private var inactiveSplitTint: some View {
@@ -141,6 +168,8 @@ private struct SplitLeafHeader: View {
     let pane: PaneDescriptorState?
     let title: (PaneDescriptorState) -> String
     let sessionStore: SessionStore?
+    let leafId: UUID
+    let dragCoordinator: WorkspaceSplitDragCoordinator?
     let onActivate: () -> Void
     let onSplit: (SplitEdge) -> Void
     let onRename: (String) -> Void
@@ -168,6 +197,7 @@ private struct SplitLeafHeader: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .simultaneousGesture(splitDragGesture)
 
             actionsMenu
         }
@@ -189,6 +219,26 @@ private struct SplitLeafHeader: View {
         case .terminal: pane?.attachOnly == true ? "server.rack" : "terminal"
         case .newTab, .none: "square.dashed"
         }
+    }
+
+    private var splitDragGesture: some Gesture {
+        DragGesture(minimumDistance: 3, coordinateSpace: .global)
+            .onChanged { value in
+                guard let pane, let dragCoordinator else { return }
+                if dragCoordinator.active?.sourceLeafId != leafId {
+                    onActivate()
+                }
+                dragCoordinator.dragUpdated(
+                    sourceLeafId: leafId,
+                    name: title(pane),
+                    kind: pane.kind,
+                    isAgentOwned: pane.attachOnly,
+                    location: value.location
+                )
+            }
+            .onEnded { _ in
+                dragCoordinator?.dragEnded()
+            }
     }
 
     @ViewBuilder
@@ -361,6 +411,7 @@ private struct SplitBranchView: View {
     let groupModel: (UUID) -> PaneGroupModel
     let paneTitle: (PaneDescriptorState) -> String
     let sessionStore: SessionStore?
+    let dragCoordinator: WorkspaceSplitDragCoordinator?
     let onSplitLeaf: (UUID, SplitEdge) -> Void
     let onRenameLeaf: (UUID, String) -> Void
     let onCloseLeaf: (UUID) -> Void
@@ -378,8 +429,8 @@ private struct SplitBranchView: View {
     /// halves would fall below it).
     private var minChildLength: CGFloat {
         orientation == .horizontal
-            ? PaneTabDragCoordinator.minChildWidth
-            : PaneTabDragCoordinator.minChildHeight
+            ? WorkspaceSplitDragCoordinator.minChildWidth
+            : WorkspaceSplitDragCoordinator.minChildHeight
     }
 
     private var fractions: [Double] { liveFractions ?? children.map(\.fraction) }
@@ -408,6 +459,7 @@ private struct SplitBranchView: View {
                         groupModel: groupModel,
                         paneTitle: paneTitle,
                         sessionStore: sessionStore,
+                        dragCoordinator: dragCoordinator,
                         onSplitLeaf: onSplitLeaf,
                         onRenameLeaf: onRenameLeaf,
                         onCloseLeaf: onCloseLeaf,

--- a/apps/macos/Codevisor/Features/Panes/WorkspaceSplitView.swift
+++ b/apps/macos/Codevisor/Features/Panes/WorkspaceSplitView.swift
@@ -1,8 +1,7 @@
-//  Renders a workspace's center split tree (the VS Code editor-grid model).
-//  Leaves are tabbed pane groups, each rendering its OWN compact tab bar
-//  over its content — a content band below the native toolbar, like
-//  Finder's tab bar. Branches are resizable splits with the same owned
-//  divider grips as the inspector; a drag rewrites the subtree's fractions
+//  Renders one workspace tab's split tree. Every leaf contains exactly one
+//  pane beneath a compact identity/action header. Branches are
+//  resizable splits with the same owned divider grips as the inspector; a
+//  drag rewrites the subtree's fractions
 //  and persists the whole tree on release.
 
 import SwiftUI
@@ -15,13 +14,11 @@ struct WorkspaceSplitView: View {
     /// focus temporarily moves to the bottom panel or another window.
     let activeLeafId: UUID?
     let groupModel: (UUID) -> PaneGroupModel
-    let chatTitle: (PaneDescriptorState) -> String
-    let paneWorktree: (PaneDescriptorState) -> String?
-    /// Content drop zones (join/split) register here.
-    var dragCoordinator: PaneTabDragCoordinator? = nil
-    /// Whether a leaf's bar shows the ⌘-shortcut hints (the primary group
-    /// while nothing else holds focus).
-    var showsShortcutHints: (UUID) -> Bool = { _ in false }
+    let paneTitle: (PaneDescriptorState) -> String
+    let sessionStore: SessionStore?
+    let onSplitLeaf: (UUID, SplitEdge) -> Void
+    let onRenameLeaf: (UUID, String) -> Void
+    let onCloseLeaf: (UUID) -> Void
     /// Called with the updated WHOLE tree after a divider drag ends.
     let onTreeChanged: (SplitNode) -> Void
     /// Called with the WHOLE tree on every frame of a divider drag (render
@@ -34,10 +31,11 @@ struct WorkspaceSplitView: View {
             activeLeafId: activeLeafId,
             dimsInactiveLeaves: node.allGroups.count > 1,
             groupModel: groupModel,
-            chatTitle: chatTitle,
-            paneWorktree: paneWorktree,
-            dragCoordinator: dragCoordinator,
-            showsShortcutHints: showsShortcutHints,
+            paneTitle: paneTitle,
+            sessionStore: sessionStore,
+            onSplitLeaf: onSplitLeaf,
+            onRenameLeaf: onRenameLeaf,
+            onCloseLeaf: onCloseLeaf,
             replaceNode: onTreeChanged,
             replaceLiveNode: { onLiveTreeChanged?($0) }
         )
@@ -49,10 +47,11 @@ private struct SplitNodeView: View {
     let activeLeafId: UUID?
     let dimsInactiveLeaves: Bool
     let groupModel: (UUID) -> PaneGroupModel
-    let chatTitle: (PaneDescriptorState) -> String
-    let paneWorktree: (PaneDescriptorState) -> String?
-    let dragCoordinator: PaneTabDragCoordinator?
-    let showsShortcutHints: (UUID) -> Bool
+    let paneTitle: (PaneDescriptorState) -> String
+    let sessionStore: SessionStore?
+    let onSplitLeaf: (UUID, SplitEdge) -> Void
+    let onRenameLeaf: (UUID, String) -> Void
+    let onCloseLeaf: (UUID) -> Void
     /// Replaces THIS node in its parent (recursion rebuilds the tree upward).
     let replaceNode: (SplitNode) -> Void
     /// Render-only twin of `replaceNode`, streamed during divider drags.
@@ -65,10 +64,11 @@ private struct SplitNodeView: View {
                 leafId: id,
                 isInactive: dimsInactiveLeaves && activeLeafId != nil && id != activeLeafId,
                 groupModel: groupModel,
-                chatTitle: chatTitle,
-                paneWorktree: paneWorktree,
-                dragCoordinator: dragCoordinator,
-                showsShortcutHints: showsShortcutHints
+                paneTitle: paneTitle,
+                sessionStore: sessionStore,
+                onSplit: { edge in onSplitLeaf(id, edge) },
+                onRename: { name in onRenameLeaf(id, name) },
+                onClose: { onCloseLeaf(id) }
             )
         case let .split(orientation, children):
             SplitBranchView(
@@ -77,10 +77,11 @@ private struct SplitNodeView: View {
                 activeLeafId: activeLeafId,
                 dimsInactiveLeaves: dimsInactiveLeaves,
                 groupModel: groupModel,
-                chatTitle: chatTitle,
-                paneWorktree: paneWorktree,
-                dragCoordinator: dragCoordinator,
-                showsShortcutHints: showsShortcutHints,
+                paneTitle: paneTitle,
+                sessionStore: sessionStore,
+                onSplitLeaf: onSplitLeaf,
+                onRenameLeaf: onRenameLeaf,
+                onCloseLeaf: onCloseLeaf,
                 replaceNode: replaceNode,
                 replaceLiveNode: replaceLiveNode
             )
@@ -88,49 +89,42 @@ private struct SplitNodeView: View {
     }
 }
 
-/// One tabbed group: its compact bar over its selected pane's content.
+/// One single-pane split leaf. The header is split chrome, not another tab
+/// group: it identifies the pane and exposes leaf-targeted split actions.
 private struct SplitLeafView: View {
     let leafId: UUID
     let isInactive: Bool
     let groupModel: (UUID) -> PaneGroupModel
-    let chatTitle: (PaneDescriptorState) -> String
-    let paneWorktree: (PaneDescriptorState) -> String?
-    let dragCoordinator: PaneTabDragCoordinator?
-    let showsShortcutHints: (UUID) -> Bool
+    let paneTitle: (PaneDescriptorState) -> String
+    let sessionStore: SessionStore?
+    let onSplit: (SplitEdge) -> Void
+    let onRename: (String) -> Void
+    let onClose: () -> Void
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         let model = groupModel(leafId)
         VStack(spacing: 0) {
-            PaneGroupBar(
-                group: model,
-                dragCoordinator: dragCoordinator,
-                chatTitle: chatTitle,
-                paneWorktree: paneWorktree,
-                showsShortcutHints: showsShortcutHints(leafId),
-                allowsNewChatTab: true,
-                dimsForInactiveSplit: isInactive,
-                chrome: .groupHeader
+            SplitLeafHeader(
+                pane: model.state.selectedPane,
+                title: paneTitle,
+                sessionStore: sessionStore,
+                onActivate: { model.onActivated?() },
+                onSplit: onSplit,
+                onRename: onRename,
+                onClose: onClose
             )
-            // The Color.clear backstop is load-bearing: if the selected
-            // pane's content resolves to nothing (EmptyView is layout-
-            // ABSENT, not just blank), the VStack would collapse to the
-            // bar and center it in the split region — and the drop zone's
-            // geometry would unregister with it.
             ZStack {
                 Color.clear
                 PaneGroupContent(group: model)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            // This sits below paneDropZone's preview overlay, keeping split
-            // targets bright while the underlying inactive content is dim.
-            .overlay {
-                inactiveSplitTint
-            }
-            // Join (⇧) / split drops land on this content.
-            .paneDropZone(dragCoordinator, leafId: leafId)
+            .contentShape(Rectangle())
+            .simultaneousGesture(TapGesture().onEnded { model.onActivated?() })
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay { inactiveSplitTint }
     }
 
     private var inactiveSplitTint: some View {
@@ -140,6 +134,142 @@ private struct SplitLeafView: View {
             .allowsHitTesting(false)
             // Active-group changes should read as focus changes, not motion.
             .transaction { $0.animation = nil }
+    }
+}
+
+private struct SplitLeafHeader: View {
+    let pane: PaneDescriptorState?
+    let title: (PaneDescriptorState) -> String
+    let sessionStore: SessionStore?
+    let onActivate: () -> Void
+    let onSplit: (SplitEdge) -> Void
+    let onRename: (String) -> Void
+    let onClose: () -> Void
+
+    @Environment(\.theme) private var theme
+    @Environment(AppEnvironment.self) private var environment
+    @State private var renameText = ""
+    @State private var showingRename = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Button(action: onActivate) {
+                HStack(spacing: 7) {
+                    leadingIcon
+
+                    Text(pane.map(title) ?? "New Tab")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(theme.textPrimary)
+
+                    Spacer(minLength: 6)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            actionsMenu
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 28)
+        .background(theme.isSystem ? Color.clear : theme.windowBackground)
+        .overlay(alignment: .bottom) { Divider() }
+        .alert(renameAlertTitle, isPresented: $showingRename) {
+            TextField("Name", text: $renameText)
+            Button("Cancel", role: .cancel) {}
+            Button("Rename") { onRename(renameText) }
+                .disabled(renameText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private var iconName: String {
+        switch pane?.kind {
+        case .chat: "text.bubble"
+        case .terminal: pane?.attachOnly == true ? "server.rack" : "terminal"
+        case .newTab, .none: "square.dashed"
+        }
+    }
+
+    @ViewBuilder
+    private var leadingIcon: some View {
+        if pane?.kind == .chat,
+           let sessionId = pane?.chatSessionId,
+           let session = environment.projectList.sessions.first(where: { $0.id == sessionId }) {
+            ChatSessionLeadingIcon(session: session, store: sessionStore)
+        } else {
+            Image(systemName: iconName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.textSecondary)
+                .frame(width: 18)
+        }
+    }
+
+    private var renameAlertTitle: String {
+        switch pane?.kind {
+        case .chat: "Rename Chat"
+        case .terminal: "Rename Terminal"
+        case .newTab, .none: "Rename Pane"
+        }
+    }
+
+    private var closeTitle: String {
+        pane?.kind == .chat && pane?.chatSessionId != nil ? "Archive" : "Close"
+    }
+
+    private var actionsMenu: some View {
+        Menu {
+            splitMenuItem("Split Right", icon: "rectangle.righthalf.inset.filled", edge: .trailing)
+            splitMenuItem("Split Left", icon: "rectangle.lefthalf.inset.filled", edge: .leading)
+            splitMenuItem("Split Down", icon: "rectangle.bottomhalf.inset.filled", edge: .bottom)
+            splitMenuItem("Split Up", icon: "rectangle.tophalf.inset.filled", edge: .top)
+
+            Divider()
+
+            Button {
+                renameText = pane.map(title) ?? "New Tab"
+                showingRename = true
+            } label: {
+                    Label("Rename", systemImage: "pencil")
+                    .labelStyle(.titleAndIcon)
+            }
+
+            Divider()
+
+            Button(role: .destructive, action: onClose) {
+                Label(closeTitle, systemImage: closeTitle == "Archive" ? "archivebox" : "xmark")
+                    .labelStyle(.titleAndIcon)
+            }
+            .keyboardShortcut("w", modifiers: .command)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(theme.textSecondary)
+                .frame(width: 24, height: 22)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Pane actions")
+        .accessibilityLabel("Pane actions")
+    }
+
+    @ViewBuilder
+    private func splitMenuItem(_ name: String, icon: String, edge: SplitEdge) -> some View {
+        let button = Button { onSplit(edge) } label: {
+            Label(name, systemImage: icon)
+                .labelStyle(.titleAndIcon)
+        }
+
+        switch edge {
+        case .trailing:
+            button.keyboardShortcut("d", modifiers: .command)
+        case .bottom:
+            button.keyboardShortcut("d", modifiers: [.command, .shift])
+        case .leading, .top:
+            button
+        }
     }
 }
 
@@ -229,10 +359,11 @@ private struct SplitBranchView: View {
     let activeLeafId: UUID?
     let dimsInactiveLeaves: Bool
     let groupModel: (UUID) -> PaneGroupModel
-    let chatTitle: (PaneDescriptorState) -> String
-    let paneWorktree: (PaneDescriptorState) -> String?
-    let dragCoordinator: PaneTabDragCoordinator?
-    let showsShortcutHints: (UUID) -> Bool
+    let paneTitle: (PaneDescriptorState) -> String
+    let sessionStore: SessionStore?
+    let onSplitLeaf: (UUID, SplitEdge) -> Void
+    let onRenameLeaf: (UUID, String) -> Void
+    let onCloseLeaf: (UUID) -> Void
     let replaceNode: (SplitNode) -> Void
     let replaceLiveNode: (SplitNode) -> Void
 
@@ -275,10 +406,11 @@ private struct SplitBranchView: View {
                         activeLeafId: activeLeafId,
                         dimsInactiveLeaves: dimsInactiveLeaves,
                         groupModel: groupModel,
-                        chatTitle: chatTitle,
-                        paneWorktree: paneWorktree,
-                        dragCoordinator: dragCoordinator,
-                        showsShortcutHints: showsShortcutHints,
+                        paneTitle: paneTitle,
+                        sessionStore: sessionStore,
+                        onSplitLeaf: onSplitLeaf,
+                        onRenameLeaf: onRenameLeaf,
+                        onCloseLeaf: onCloseLeaf,
                         replaceNode: { newChild in
                             var updated = children
                             updated[index] = SplitChild(

--- a/apps/macos/Codevisor/Features/Panes/WorkspaceTabBar.swift
+++ b/apps/macos/Codevisor/Features/Panes/WorkspaceTabBar.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import CodevisorCore
+
+/// The workspace's browser-style ownership layer rendered in the same
+/// native capsule strip used by the previous pane tabs. Each item now owns
+/// a complete split layout instead of belonging to one split leaf.
+struct WorkspaceTabBar: View {
+    let tabs: [WorkspaceTab]
+    let selectedTabId: UUID
+    let title: (WorkspaceTab) -> String
+    let descriptor: (WorkspaceTab) -> PaneDescriptorState?
+    let paneWorktree: (PaneDescriptorState) -> String?
+    let onSelect: (UUID) -> Void
+    let onClose: (UUID) -> Void
+    let onMove: (UUID, UUID) -> Void
+    let onNew: () -> Void
+
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+
+    private let barHeight: CGFloat = 28
+    private let minimumTabWidth: CGFloat = 100
+    private let addButtonDiameter: CGFloat = 26
+
+    var body: some View {
+        GeometryReader { geometry in
+            let available = max(
+                geometry.size.width - addButtonDiameter - 12,
+                minimumTabWidth
+            )
+            let fitted = available / CGFloat(max(tabs.count, 1))
+            let tabWidth = max(minimumTabWidth, fitted)
+            let stripWidth = max(available, tabWidth * CGFloat(tabs.count))
+
+            HStack(spacing: 4) {
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal) {
+                        HStack(spacing: 0) {
+                            ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+                                let pane = descriptor(tab)
+                                PaneTab(
+                                    name: title(tab),
+                                    kind: pane?.kind ?? .newTab,
+                                    worktree: pane.flatMap(paneWorktree),
+                                    isAgentOwned: pane?.attachOnly ?? false,
+                                    isSelected: tab.id == selectedTabId,
+                                    isDragging: false,
+                                    width: tabWidth,
+                                    canClose: true,
+                                    showsTrailingSeparator: index < tabs.count - 1
+                                        && tab.id != selectedTabId
+                                        && tabs[index + 1].id != selectedTabId,
+                                    shortcutHint: nil,
+                                    onSelect: { onSelect(tab.id) },
+                                    onClose: { onClose(tab.id) }
+                                )
+                                .id(tab.id)
+                                .onDrag {
+                                    NSItemProvider(object: tab.id.uuidString as NSString)
+                                }
+                                .onDrop(
+                                    of: [.plainText],
+                                    delegate: WorkspaceTabDropDelegate(
+                                        targetId: tab.id,
+                                        onMove: onMove
+                                    )
+                                )
+                            }
+                        }
+                        .frame(width: stripWidth, height: barHeight, alignment: .leading)
+                        .background(
+                            Capsule()
+                                .fill(colorScheme == .dark
+                                    ? Color.white.opacity(0.12)
+                                    : Color.black.opacity(0.06))
+                        )
+                    }
+                    .scrollIndicators(.hidden)
+                    .onChange(of: selectedTabId, initial: true) { _, selected in
+                        withAnimation(PaneGroupBar.tabMotion) {
+                            proxy.scrollTo(selected, anchor: .center)
+                        }
+                    }
+                }
+                .frame(width: available, height: barHeight)
+
+                Button(action: onNew) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(theme.textPrimary)
+                        .frame(width: addButtonDiameter, height: addButtonDiameter)
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .glassEffect(.regular.interactive(), in: Circle())
+                .help("New tab (⌘T)")
+                .accessibilityLabel("New tab")
+
+                Spacer(minLength: 0)
+            }
+            .animation(PaneGroupBar.tabMotion, value: tabs.map(\.id))
+        }
+        .frame(height: barHeight)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+}
+
+private struct WorkspaceTabDropDelegate: DropDelegate {
+    let targetId: UUID
+    let onMove: (UUID, UUID) -> Void
+
+    func dropEntered(info: DropInfo) {
+        guard let provider = info.itemProviders(for: [.plainText]).first else { return }
+        provider.loadObject(ofClass: NSString.self) { object, _ in
+            guard let value = object as? String,
+                  let sourceId = UUID(uuidString: value),
+                  sourceId != targetId else { return }
+            Task { @MainActor in onMove(sourceId, targetId) }
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool { true }
+}

--- a/apps/macos/Codevisor/Features/Session/SessionContainerView.swift
+++ b/apps/macos/Codevisor/Features/Session/SessionContainerView.swift
@@ -22,9 +22,6 @@ struct SessionContainerView: View {
     @Environment(\.theme) private var theme
     @Environment(AdaptivePanelLayout.self) private var panelLayout
     @State private var controller: SessionController?
-    /// Cross-group tab dragging, shared by the header pane strip and the
-    /// session screen's bottom panel.
-    @State private var paneDragCoordinator = PaneTabDragCoordinator()
     /// The session's focus coordinator (composer ⇄ terminals). Owned here so
     /// every center leaf's chat content — any group can host chats — wires
     /// against the same instance.
@@ -52,6 +49,11 @@ struct SessionContainerView: View {
     /// tab commands (⌘T/⌘W/⌘1-9/⌘⌥←→) route here and its bar shows the
     /// ⌘-hints. Defaults to the primary (chat) leaf.
     @State private var activeLeafId: UUID?
+    /// Repository writes are intentionally non-observable. Structural tab
+    /// changes bump this token so the strip and selected tree re-read truth.
+    @State private var workspaceRevision = 0
+    /// Suppresses per-leaf dissolve while a whole top tab is closing.
+    @State private var closingCenterTabId: UUID?
 
     private var inspectorVisible: Bool {
         panelLayout.docksInspector && scratchpad.isVisible
@@ -109,6 +111,24 @@ struct SessionContainerView: View {
         .focusedSceneValue(\.scratchpadToggle, ScratchpadToggleAction(sessionId: session.id) {
             toggleScratchpad()
         })
+        .focusedSceneValue(
+            \.workspaceLayoutActions,
+            WorkspaceLayoutActions(
+                workspaceId: store.workspace(for: session, project: project).id,
+                newTab: addCenterTab,
+                closeSplit: closeActiveLeaf,
+                closeTab: {
+                    let workspace = store.workspace(for: session, project: project)
+                    closeCenterTab(workspace.selectedCenterTabId)
+                },
+                previousTab: { selectRelativeCenterTab(offset: -1) },
+                nextTab: { selectRelativeCenterTab(offset: 1) },
+                previousSplit: { focusRelativeSplit(offset: -1) },
+                nextSplit: { focusRelativeSplit(offset: 1) },
+                split: splitActiveLeaf,
+                focus: focusAdjacentLeaf
+            )
+        )
         // Background tasks that stream through a server-owned terminal get a
         // tab in the bottom panel — a dev server is something running, not
         // something a chat is waiting on. Synced at the WORKSPACE level
@@ -126,8 +146,30 @@ struct SessionContainerView: View {
             // chat's TAB selected in it (the sidebar picked this chat — it
             // must be the one facing the user, not whichever tab its group
             // last showed).
-            if let primaryLeaf = store.workspace(for: session, project: project)
-                .centerTree.groupId(containingChat: session.id) {
+            var routedWorkspace = store.workspace(for: session, project: project)
+            let liveRoutedSession = environment.projectList.sessions.first {
+                $0.serverId == session.serverId && $0.id == session.id
+            } ?? session
+            // A chat removed by closing its old pane keeps its grow-only
+            // workspace index. If it is later restored/unarchived, route it
+            // back into that workspace as a fresh single-chat top tab.
+            if !liveRoutedSession.isArchived,
+               routedWorkspace.tabId(containingChat: session.id) == nil {
+                let tab = WorkspaceTab(root: .leaf(.centerInitial(sessionId: session.id)))
+                routedWorkspace.centerTabs.append(tab)
+                routedWorkspace.selectedCenterTabId = tab.id
+                environment.workspaces.save(routedWorkspace)
+                workspaceRevision += 1
+                liveCenterTree = tab.root
+            }
+            if let routedTabId = routedWorkspace.tabId(containingChat: session.id),
+               routedWorkspace.selectedCenterTabId != routedTabId {
+                routedWorkspace.selectedCenterTabId = routedTabId
+                environment.workspaces.save(routedWorkspace)
+                workspaceRevision += 1
+                liveCenterTree = routedWorkspace.centerTree
+            }
+            if let primaryLeaf = routedWorkspace.centerTree.groupId(containingChat: session.id) {
                 let model = configuredCenterModel(leafId: primaryLeaf)
                 if let chatPane = model.state.panes.first(where: {
                     $0.kind == .chat && $0.chatSessionId == session.id
@@ -142,27 +184,26 @@ struct SessionContainerView: View {
                 // if it's already registered, else the moment its
                 // (possibly later-laid-out) pane registers it.
                 sessionFocus.requestComposerFocus(forChat: session.id)
-            } else if let firstLeaf = store.workspace(for: session, project: project)
-                .centerTree.allGroups.first?.id {
+            } else if let firstLeaf = routedWorkspace.centerTree.allGroups.first?.id {
                 // A legacy or draft CHAT-LESS workspace routed here through
                 // the grow-only session index uses its first group as the
                 // keyboard target.
                 _ = configuredCenterModel(leafId: firstLeaf)
                 activateLeaf(firstLeaf)
             }
-            // Cross-group drops: bar inserts, content joins, and splits.
-            paneDragCoordinator.onResolve = { paneId, source, resolution in
-                resolvePaneDrop(paneId: paneId, source: source, resolution: resolution)
-            }
-            // The bottom panel's spawns follow the focused CENTER context
-            // too: a worktree chat's ⌘T terminal lands in its worktree.
+            // Bottom-panel spawns from its local + action follow the focused
+            // center context too.
             store.paneGroup(for: session, project: project).defaultSpawnCwd = {
                 focusedSpawnCwd()
             }
-            // ⌘W's window-close guard: repo truth on whether tabs remain.
-            sessionFocus.hasOtherCenterTabs = { [store] in
-                store.workspace(for: session, project: project)
-                    .centerTree.allGroups.flatMap(\.state.panes).count > 1
+            store.paneGroup(for: session, project: project).workspaceCommandHandler = { command in
+                switch command {
+                case .newTab, .previousTab, .nextTab, .selectTab, .split, .focusSplit,
+                     .previousSplit, .nextSplit:
+                    return handleWorkspaceCommand(command)
+                case .closeTab, .togglePanel:
+                    return false
+                }
             }
             // Upward focus feedback: clicking into any chat's composer
             // makes its group the active one (terminals do the same through
@@ -197,8 +238,8 @@ struct SessionContainerView: View {
         }
     }
 
-    /// The session content: every pane group renders its own tab bar (the
-    /// Finder model — tabs are a content band below the native toolbar).
+    /// The session content: a browser-style tab bar above the selected
+    /// tab's split layout.
     /// The EXPLICIT page fill matters: the bare NavigationSplitView detail
     /// surface is the NSWindow background, which desktop tinting shifts a
     /// few shades — the terminal's opaque surface can't follow that, so
@@ -206,28 +247,42 @@ struct SessionContainerView: View {
     private var contentColumn: some View {
         Group {
             if let controller {
+                let _ = workspaceRevision
                 let workspace = store.workspace(for: session, project: project)
-                SessionScreen(
-                    controller: controller,
-                    paneGroup: store.paneGroup(for: session, project: project),
-                    centerGroup: store.centerPaneGroup(for: session, project: project),
-                    dragCoordinator: paneDragCoordinator,
-                    focus: sessionFocus,
-                    centerTree: liveCenterTree ?? workspace.centerTree,
-                    primaryLeafId: workspace.centerTree.groupId(containingChat: session.id),
-                    activeLeafId: activeLeafId,
-                    centerLeafModel: { leafId in configuredCenterModel(leafId: leafId) },
-                    chatTitleLookup: chatPaneTitle,
-                    paneWorktreeLookup: paneWorktreeBadge,
-                    onCenterTreeChanged: { tree in
-                        liveCenterTree = tree
-                        store.saveCenterTree(tree, workspaceId: workspace.id)
-                    },
-                    // Divider mid-drag: render-only re-layout.
-                    onCenterTreeLiveChanged: { tree in
-                        liveCenterTree = tree
-                    }
-                )
+                VStack(spacing: 0) {
+                    WorkspaceTabBar(
+                        tabs: workspace.centerTabs,
+                        selectedTabId: workspace.selectedCenterTabId,
+                        title: workspaceTabTitle,
+                        descriptor: workspaceTabDescriptor,
+                        paneWorktree: paneWorktreeBadge,
+                        onSelect: selectCenterTab,
+                        onClose: closeCenterTab,
+                        onMove: moveCenterTab,
+                        onNew: addCenterTab
+                    )
+                    SessionScreen(
+                        controller: controller,
+                        paneGroup: store.paneGroup(for: session, project: project),
+                        centerGroup: activeCenterModel(in: workspace),
+                        focus: sessionFocus,
+                        centerTree: liveCenterTree ?? workspace.centerTree,
+                        primaryLeafId: workspace.centerTree.groupId(containingChat: session.id),
+                        activeLeafId: activeLeafId ?? workspace.selectedCenterTab?.activeLeafId,
+                        centerLeafModel: { leafId in configuredCenterModel(leafId: leafId) },
+                        centerPaneTitle: paneTitle,
+                        sessionStore: store,
+                        onSplitLeaf: splitLeaf,
+                        onRenameLeaf: renameLeaf,
+                        onCloseLeaf: closeLeaf,
+                        paneWorktreeLookup: paneWorktreeBadge,
+                        onCenterTreeChanged: { tree in
+                            liveCenterTree = tree
+                            saveSelectedTree(tree, workspaceId: workspace.id)
+                        },
+                        onCenterTreeLiveChanged: { tree in liveCenterTree = tree }
+                    )
+                }
             } else {
                 ProgressView()
                     .controlSize(.small)
@@ -265,14 +320,299 @@ struct SessionContainerView: View {
         )
     }
 
-    /// The group model behind a drop ref.
-    private func groupModel(for ref: PaneGroupRef) -> PaneGroupModel {
-        switch ref {
-        case .bottom:
-            return store.paneGroup(for: session, project: project)
-        case let .centerLeaf(leafId):
-            return configuredCenterModel(leafId: leafId)
+    // MARK: - Workspace tabs and split commands
+
+    private func activeCenterModel(in workspace: Workspace) -> PaneGroupModel {
+        let leafId = activeLeafId
+            ?? workspace.selectedCenterTab?.activeLeafId
+            ?? workspace.centerTree.allGroups.first!.id
+        return configuredCenterModel(leafId: leafId)
+    }
+
+    private func workspaceTabDescriptor(_ tab: WorkspaceTab) -> PaneDescriptorState? {
+        configuredCenterModel(leafId: tab.activeLeafId).state.selectedPane
+            ?? tab.root.group(id: tab.activeLeafId)?.selectedPane
+            ?? tab.root.allGroups.first?.state.selectedPane
+    }
+
+    private func workspaceTabTitle(_ tab: WorkspaceTab) -> String {
+        guard let descriptor = workspaceTabDescriptor(tab) else { return "New Tab" }
+        return paneTitle(descriptor)
+    }
+
+    private func selectCenterTab(_ tabId: UUID) {
+        var workspace = store.workspace(for: session, project: project)
+        guard let tab = workspace.centerTabs.first(where: { $0.id == tabId }) else { return }
+        if let old = workspace.selectedCenterTab, old.id != tabId {
+            for leaf in old.root.allGroups {
+                configuredCenterModel(leafId: leaf.id).selectedPane?.visibilityChanged(false)
+            }
         }
+        workspace.selectedCenterTabId = tabId
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+        liveCenterTree = tab.root
+        activateLeaf(tab.activeLeafId)
+        let model = configuredCenterModel(leafId: tab.activeLeafId)
+        model.selectedPane?.visibilityChanged(true)
+        DispatchQueue.main.async { model.focusSelectedPane() }
+    }
+
+    private func addCenterTab() {
+        var workspace = store.workspace(for: session, project: project)
+        if let current = workspace.selectedCenterTab {
+            for leaf in current.root.allGroups {
+                configuredCenterModel(leafId: leaf.id).selectedPane?.visibilityChanged(false)
+            }
+        }
+        var state = PaneGroupState()
+        _ = state.addNewTabPane(inheritedCwd: focusedSpawnCwd())
+        let tab = WorkspaceTab(root: .leaf(state))
+        workspace.centerTabs.append(tab)
+        workspace.selectedCenterTabId = tab.id
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+        liveCenterTree = tab.root
+        activateLeaf(tab.activeLeafId)
+    }
+
+    private func moveCenterTab(_ sourceId: UUID, _ targetId: UUID) {
+        var workspace = store.workspace(for: session, project: project)
+        guard sourceId != targetId,
+              let source = workspace.centerTabs.firstIndex(where: { $0.id == sourceId }),
+              let target = workspace.centerTabs.firstIndex(where: { $0.id == targetId }) else { return }
+        let tab = workspace.centerTabs.remove(at: source)
+        workspace.centerTabs.insert(tab, at: target)
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+    }
+
+    private func closeCenterTab(_ tabId: UUID) {
+        var workspace = store.workspace(for: session, project: project)
+        guard let index = workspace.centerTabs.firstIndex(where: { $0.id == tabId }) else { return }
+        let closing = workspace.centerTabs[index]
+        let closesRoutedChat = closing.root.allGroups.contains { group in
+            group.state.panes.contains { $0.chatSessionId == session.id }
+        }
+        closingCenterTabId = tabId
+        for leaf in closing.root.allGroups {
+            let model = configuredCenterModel(leafId: leaf.id)
+            if let paneId = model.state.selectedPaneId {
+                model.closePane(id: paneId)
+            }
+            store.evictCenterLeaf(workspaceId: workspace.id, leafId: leaf.id)
+        }
+        closingCenterTabId = nil
+
+        // Re-read after each leaf persisted its empty group, then remove the
+        // whole layout atomically from repository truth.
+        workspace = store.workspace(for: session, project: project)
+        guard let refreshedIndex = workspace.centerTabs.firstIndex(where: { $0.id == tabId }) else {
+            return
+        }
+        workspace.centerTabs.remove(at: refreshedIndex)
+        if workspace.centerTabs.isEmpty {
+            var state = PaneGroupState()
+            _ = state.addNewTabPane(inheritedCwd: workspace.rootDirectory)
+            let replacement = WorkspaceTab(root: .leaf(state))
+            workspace.centerTabs = [replacement]
+            workspace.selectedCenterTabId = replacement.id
+        } else if workspace.selectedCenterTabId == tabId {
+            workspace.selectedCenterTabId = workspace.centerTabs[
+                min(refreshedIndex, workspace.centerTabs.count - 1)
+            ].id
+        }
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+        liveCenterTree = workspace.centerTree
+        activateLeaf(workspace.selectedCenterTab?.activeLeafId)
+        if closesRoutedChat, let survivor = firstSurvivingChatId() {
+            onFocusedChatChanged?(survivor)
+        }
+    }
+
+    private func saveSelectedTree(_ tree: SplitNode, workspaceId: UUID) {
+        guard var workspace = environment.workspaces.workspace(id: workspaceId),
+              let index = workspace.selectedCenterTabIndex else { return }
+        // Divider callbacks carry render-time topology/fractions. Merge the
+        // repository's live leaf states so a recent New Tab conversion or
+        // title/session binding can never be overwritten by a resize.
+        var merged = tree
+        for group in workspace.centerTabs[index].root.allGroups {
+            merged = merged.updatingGroup(id: group.id) { _ in group.state }
+        }
+        workspace.centerTabs[index].root = merged
+        if merged.group(id: workspace.centerTabs[index].activeLeafId) == nil,
+           let first = merged.allGroups.first?.id {
+            workspace.centerTabs[index].activeLeafId = first
+        }
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+    }
+
+    private func handleWorkspaceCommand(_ command: PaneGroupCommand) -> Bool {
+        switch command {
+        case .newTab:
+            addCenterTab()
+        case .previousTab:
+            selectRelativeCenterTab(offset: -1)
+        case .nextTab:
+            selectRelativeCenterTab(offset: 1)
+        case let .selectTab(index):
+            let workspace = store.workspace(for: session, project: project)
+            guard workspace.centerTabs.indices.contains(index) else { return true }
+            selectCenterTab(workspace.centerTabs[index].id)
+        case let .split(edge):
+            splitActiveLeaf(edge: edge)
+        case let .focusSplit(edge):
+            focusAdjacentLeaf(edge: edge)
+        case .previousSplit:
+            focusRelativeSplit(offset: -1)
+        case .nextSplit:
+            focusRelativeSplit(offset: 1)
+        case .closeTab:
+            closeActiveLeaf()
+        case .togglePanel:
+            return false
+        }
+        return true
+    }
+
+    private func selectRelativeCenterTab(offset: Int) {
+        let workspace = store.workspace(for: session, project: project)
+        guard workspace.centerTabs.count > 1,
+              let index = workspace.selectedCenterTabIndex else { return }
+        let target = (index + offset + workspace.centerTabs.count) % workspace.centerTabs.count
+        selectCenterTab(workspace.centerTabs[target].id)
+    }
+
+    private func splitActiveLeaf(edge: SplitEdge) {
+        let workspace = store.workspace(for: session, project: project)
+        guard let tab = workspace.selectedCenterTab else { return }
+        splitLeaf(activeLeafId ?? tab.activeLeafId, edge: edge)
+    }
+
+    /// Splits the explicitly targeted leaf. Header buttons call this with
+    /// their owning leaf; keyboard/menu commands pass the active leaf.
+    private func splitLeaf(_ leafId: UUID, edge: SplitEdge) {
+        var workspace = store.workspace(for: session, project: project)
+        guard let tabIndex = workspace.centerTabs.firstIndex(where: {
+            $0.root.group(id: leafId) != nil
+        }) else { return }
+        let inheritedCwd = spawnCwd(for: leafId, in: workspace)
+        var state = PaneGroupState()
+        _ = state.addNewTabPane(inheritedCwd: inheritedCwd)
+        let newLeafId = UUID()
+        workspace.centerTabs[tabIndex].root = workspace.centerTabs[tabIndex].root.splitting(
+            groupId: leafId,
+            edge: edge,
+            newGroupId: newLeafId,
+            newGroupState: state
+        )
+        workspace.centerTabs[tabIndex].activeLeafId = newLeafId
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+        liveCenterTree = workspace.centerTabs[tabIndex].root
+        activateLeaf(newLeafId)
+    }
+
+    private func closeActiveLeaf() {
+        let workspace = store.workspace(for: session, project: project)
+        guard let tab = workspace.selectedCenterTab else { return }
+        closeLeaf(activeLeafId ?? tab.activeLeafId)
+    }
+
+    private func closeLeaf(_ leafId: UUID) {
+        let model = configuredCenterModel(leafId: leafId)
+        guard let paneId = model.state.selectedPaneId else { return }
+        model.closePane(id: paneId)
+    }
+
+    private func renameLeaf(_ leafId: UUID, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let model = configuredCenterModel(leafId: leafId)
+        guard let descriptor = model.state.selectedPane else { return }
+        model.renamePane(id: descriptor.id, to: trimmed)
+        if descriptor.kind == .chat,
+           let chatId = descriptor.chatSessionId,
+           let chat = environment.projectList.sessions.first(where: {
+               $0.serverId == session.serverId && $0.id == chatId
+           }) {
+            environment.projectList.renameSession(chat, to: trimmed)
+        }
+    }
+
+    private func focusAdjacentLeaf(edge: SplitEdge) {
+        let workspace = store.workspace(for: session, project: project)
+        guard let tab = workspace.selectedCenterTab else { return }
+        let current = activeLeafId ?? tab.activeLeafId
+        let frames = normalizedLeafFrames(tab.root)
+        guard let source = frames[current] else { return }
+        let sourceCenter = CGPoint(x: source.midX, y: source.midY)
+        let candidates = frames.filter { id, frame in
+            guard id != current else { return false }
+            switch edge {
+            case .leading: return frame.midX < sourceCenter.x
+            case .trailing: return frame.midX > sourceCenter.x
+            case .top: return frame.midY < sourceCenter.y
+            case .bottom: return frame.midY > sourceCenter.y
+            }
+        }
+        let target = candidates.min { lhs, rhs in
+            let ld = hypot(lhs.value.midX - sourceCenter.x, lhs.value.midY - sourceCenter.y)
+            let rd = hypot(rhs.value.midX - sourceCenter.x, rhs.value.midY - sourceCenter.y)
+            return ld < rd
+        }?.key
+        guard let target else { return }
+        activateLeaf(target)
+        DispatchQueue.main.async { configuredCenterModel(leafId: target).focusSelectedPane() }
+    }
+
+    /// Cycles through split leaves in stable visual reading order. This is
+    /// deliberately independent of split orientation so ⌘[ / ⌘] remains
+    /// predictable in nested horizontal and vertical layouts.
+    private func focusRelativeSplit(offset: Int) {
+        let workspace = store.workspace(for: session, project: project)
+        guard let tab = workspace.selectedCenterTab else { return }
+        let leaves = tab.root.allGroups.map(\.id)
+        guard leaves.count > 1 else { return }
+        let current = activeLeafId ?? tab.activeLeafId
+        let index = leaves.firstIndex(of: current) ?? 0
+        let target = leaves[(index + offset + leaves.count) % leaves.count]
+        activateLeaf(target)
+        DispatchQueue.main.async { configuredCenterModel(leafId: target).focusSelectedPane() }
+    }
+
+    private func normalizedLeafFrames(_ root: SplitNode) -> [UUID: CGRect] {
+        var result: [UUID: CGRect] = [:]
+        func walk(_ node: SplitNode, in frame: CGRect) {
+            switch node {
+            case let .group(id, _):
+                result[id] = frame
+            case let .split(orientation, children):
+                var cursor: CGFloat = 0
+                for child in children {
+                    let fraction = CGFloat(child.fraction)
+                    let childFrame: CGRect
+                    if orientation == .horizontal {
+                        childFrame = CGRect(
+                            x: frame.minX + frame.width * cursor, y: frame.minY,
+                            width: frame.width * fraction, height: frame.height
+                        )
+                    } else {
+                        childFrame = CGRect(
+                            x: frame.minX, y: frame.minY + frame.height * cursor,
+                            width: frame.width, height: frame.height * fraction
+                        )
+                    }
+                    walk(child.node, in: childFrame)
+                    cursor += fraction
+                }
+            }
+        }
+        walk(root, in: CGRect(x: 0, y: 0, width: 1, height: 1))
+        return result
     }
 
     /// A center leaf's model with the container's lifecycle hooks attached
@@ -287,11 +627,13 @@ struct SessionContainerView: View {
         // Acting in a group makes it the ACTIVE one: keyboard tab commands
         // follow the user (routed via the focus controller's centerGroup).
         model.onActivated = { [weak model] in
-            guard activeLeafId != leafId else { return }
-            activeLeafId = leafId
+            activateLeaf(leafId)
             if let model {
                 sessionFocus.centerGroup = model
             }
+        }
+        model.workspaceCommandHandler = { command in
+            handleWorkspaceCommand(command)
         }
         // cwd follows focus: ⌘T / bar "+" spawns inherit the focused pane's
         // context (a worktree chat's terminal opens in the worktree).
@@ -331,19 +673,8 @@ struct SessionContainerView: View {
                     // never points at an archived session (focus may land
                     // on a terminal, which reports nothing).
                     if closedSessionId == session.id,
-                       let survivor = store.workspace(for: session, project: project)
-                        .centerTree.allGroups
-                        .flatMap(\.state.panes)
-                        .first(where: { descriptor in
-                            guard descriptor.kind == .chat,
-                                  let candidateId = descriptor.chatSessionId else { return false }
-                            return environment.projectList.sessions.contains {
-                                $0.serverId == session.serverId
-                                    && $0.id == candidateId
-                                    && !$0.isArchived
-                            }
-                        })?
-                        .chatSessionId {
+                       closingCenterTabId == nil,
+                       let survivor = firstSurvivingChatId() {
                         onFocusedChatChanged?(survivor)
                     }
                 } else {
@@ -351,14 +682,13 @@ struct SessionContainerView: View {
                     store.removePaneDraft(paneId: descriptor.id)
                 }
             }
-            // Closing a group's last tab dissolves the group.
-            dissolveIfEmpty(leafId: leafId)
+            if closingCenterTabId == nil {
+                dissolveIfEmpty(leafId: leafId)
+            }
         }
         // A lone New Tab placeholder's close dissolves its group — possible
         // whenever the workspace has other groups.
-        model.canDissolve = {
-            store.workspace(for: session, project: project).centerTree.allGroups.count > 1
-        }
+        model.canDissolve = { true }
         // Any center group can host chats (established or draft) and the
         // New Tab placeholder. Weak model: the closure is held BY the model.
         // Re-wired UNCONDITIONALLY (safe: @ObservationIgnored): the models
@@ -389,15 +719,19 @@ struct SessionContainerView: View {
         return model
     }
 
-    /// The cwd a context-free spawn (⌘T, bar "+") inherits: the active
+    /// The cwd a new top tab, split, or bottom-panel spawn inherits: the active
     /// center group's selected pane's context — a chat's live session cwd,
     /// a terminal's own override — falling back to the workspace root.
     /// Root is returned EXPLICITLY (not nil) so a root-context spawn stays
     /// at root even when the group's anchor session runs in a worktree.
     private func focusedSpawnCwd() -> String? {
         let workspace = store.workspace(for: session, project: project)
+        return spawnCwd(for: activeLeafId, in: workspace)
+    }
+
+    private func spawnCwd(for leafId: UUID?, in workspace: Workspace) -> String? {
         let root = workspace.rootDirectory ?? project.folderURL.path
-        guard let leafId = activeLeafId else { return root }
+        guard let leafId else { return root }
         let selected = store.centerGroup(
             leafId: leafId, workspace: workspace, session: session, project: project
         ).state.selectedPane
@@ -455,31 +789,50 @@ struct SessionContainerView: View {
         sessionFocus.requestComposerFocus(forChat: created.id)
     }
 
-    /// Removes an emptied center leaf from the tree: siblings absorb its
-    /// share, single-child splits collapse (VS Code's rule). The workspace's
-    /// LAST group can't dissolve — Chrome's rule instead: its empty state
-    /// becomes a "New tab" placeholder tab, so the strip never empties.
+    /// Removes an emptied split leaf. If it was its tab's final leaf, the
+    /// whole top tab closes; the workspace's final tab is replaced by a New
+    /// Tab page so the working surface itself never disappears.
     private func dissolveIfEmpty(leafId: UUID) {
-        let workspace = store.workspace(for: session, project: project)
+        var workspace = store.workspace(for: session, project: project)
         let model = store.centerGroup(
             leafId: leafId, workspace: workspace, session: session, project: project
         )
         guard model.state.panes.isEmpty else { return }
-        // Repo truth, never the render cache — group states in
-        // liveCenterTree go stale as models persist.
-        if let pruned = workspace.centerTree.removingGroup(id: leafId) {
+        guard let tabIndex = workspace.centerTabs.firstIndex(where: {
+            $0.root.group(id: leafId) != nil
+        }) else { return }
+        let oldLeafIds = workspace.centerTabs[tabIndex].root.allGroups.map(\.id)
+        if let pruned = workspace.centerTabs[tabIndex].root.removingGroup(id: leafId) {
+            workspace.centerTabs[tabIndex].root = pruned
+            let oldIndex = oldLeafIds.firstIndex(of: leafId) ?? 0
+            let survivors = pruned.allGroups.map(\.id)
+            workspace.centerTabs[tabIndex].activeLeafId = survivors[
+                min(oldIndex, survivors.count - 1)
+            ]
+            environment.workspaces.save(workspace)
             liveCenterTree = pruned
-            store.saveCenterTree(pruned, workspaceId: workspace.id)
-            paneDragCoordinator.clearGeometry(for: .centerLeaf(leafId))
-            paneDragCoordinator.clearContentFrame(leafId: leafId)
             store.evictCenterLeaf(workspaceId: workspace.id, leafId: leafId)
-            // A dissolved active group hands the keyboard back to the
-            // primary (chat) leaf.
-            if activeLeafId == leafId {
-                activateLeaf(pruned.groupId(containingChat: session.id) ?? pruned.allGroups.first?.id)
-            }
+            workspaceRevision += 1
+            activateLeaf(workspace.centerTabs[tabIndex].activeLeafId)
         } else {
-            model.addNewTabPane()
+            let closingTabId = workspace.centerTabs[tabIndex].id
+            workspace.centerTabs.remove(at: tabIndex)
+            if workspace.centerTabs.isEmpty {
+                var state = PaneGroupState()
+                _ = state.addNewTabPane(inheritedCwd: workspace.rootDirectory)
+                let replacement = WorkspaceTab(root: .leaf(state))
+                workspace.centerTabs = [replacement]
+                workspace.selectedCenterTabId = replacement.id
+            } else if workspace.selectedCenterTabId == closingTabId {
+                workspace.selectedCenterTabId = workspace.centerTabs[
+                    min(tabIndex, workspace.centerTabs.count - 1)
+                ].id
+            }
+            environment.workspaces.save(workspace)
+            store.evictCenterLeaf(workspaceId: workspace.id, leafId: leafId)
+            workspaceRevision += 1
+            liveCenterTree = workspace.centerTree
+            activateLeaf(workspace.selectedCenterTab?.activeLeafId)
         }
     }
 
@@ -487,64 +840,27 @@ struct SessionContainerView: View {
     private func activateLeaf(_ leafId: UUID?) {
         activeLeafId = leafId
         if let leafId {
+            var workspace = store.workspace(for: session, project: project)
+            if let tabIndex = workspace.centerTabs.firstIndex(where: {
+                $0.root.group(id: leafId) != nil
+            }) {
+                var changed = false
+                if workspace.selectedCenterTabId != workspace.centerTabs[tabIndex].id {
+                    workspace.selectedCenterTabId = workspace.centerTabs[tabIndex].id
+                    liveCenterTree = workspace.centerTabs[tabIndex].root
+                    changed = true
+                }
+                if workspace.centerTabs[tabIndex].activeLeafId != leafId {
+                    workspace.centerTabs[tabIndex].activeLeafId = leafId
+                    changed = true
+                }
+                if changed {
+                    environment.workspaces.save(workspace)
+                    workspaceRevision += 1
+                }
+            }
             sessionFocus.centerGroup = configuredCenterModel(leafId: leafId)
         }
-    }
-
-    /// Performs a resolved cross-group drop: extracts the LIVE pane from its
-    /// source (the terminal keeps its PTY), then inserts it into the target
-    /// bar slot, appends it to a group (content-center join), or splits a
-    /// leaf with it. A center leaf left empty dissolves out of the tree
-    /// (its siblings absorb the space — VS Code's rule).
-    private func resolvePaneDrop(
-        paneId: UUID,
-        source: PaneGroupRef,
-        resolution: PaneDropResolution
-    ) {
-        let workspace = store.workspace(for: session, project: project)
-        let sourceModel = groupModel(for: source)
-        guard let (descriptor, livePane) = sourceModel.extractPane(id: paneId) else { return }
-
-        let destination: PaneGroupModel
-        switch resolution {
-        case let .bar(ref, index):
-            destination = groupModel(for: ref)
-            destination.adoptPane(descriptor, live: livePane, at: index)
-        case let .join(ref):
-            destination = groupModel(for: ref)
-            destination.adoptPane(descriptor, live: livePane, at: Int.max)
-        case let .split(leafId, edge):
-            let newGroupId = UUID()
-            // Re-read the tree AFTER the extraction: the extract just
-            // persisted the source group's new state into the workspace, and
-            // splitting a pre-extract snapshot would resurrect the moved
-            // pane in its old group.
-            let tree = store.workspace(for: session, project: project).centerTree.splitting(
-                groupId: leafId,
-                edge: edge,
-                newGroupId: newGroupId,
-                // The group is born empty; adoptPane below inserts the pane
-                // and registers its live object in one path.
-                newGroupState: PaneGroupState(isVisible: true)
-            )
-            liveCenterTree = tree
-            store.saveCenterTree(tree, workspaceId: workspace.id)
-            destination = groupModel(for: .centerLeaf(newGroupId))
-            destination.adoptPane(descriptor, live: livePane, at: 0)
-        }
-
-        // Dissolve an emptied source leaf (never the chat's — the chat can't
-        // leave its group, so its leaf can't empty).
-        if case let .centerLeaf(sourceLeafId) = source {
-            dissolveIfEmpty(leafId: sourceLeafId)
-        }
-
-        // The drop was a multi-step operation (extract → mutate tree →
-        // adopt → dissolve), and the render cache picked up intermediate
-        // snapshots along the way — end on repository truth, always.
-        liveCenterTree = store.workspace(for: session, project: project).centerTree
-
-        DispatchQueue.main.async { destination.focusSelectedPane() }
     }
 
     /// Whether an established chat hasn't truly begun: no agent session ever
@@ -582,11 +898,30 @@ struct SessionContainerView: View {
         }
     }
 
+    private func paneTitle(_ descriptor: PaneDescriptorState) -> String {
+        descriptor.kind == .chat ? chatPaneTitle(descriptor) : descriptor.name
+    }
+
     private func chatPaneTitle(_ descriptor: PaneDescriptorState) -> String {
         guard let id = descriptor.chatSessionId else { return descriptor.name }
         return environment.projectList.sessions.first {
             $0.serverId == session.serverId && $0.id == id
         }?.title ?? descriptor.name
+    }
+
+    private func firstSurvivingChatId() -> UUID? {
+        let descriptors = store.workspace(for: session, project: project)
+            .centerTabs.flatMap { tab in tab.root.allGroups }
+            .flatMap { group in group.state.panes }
+        return descriptors.first { descriptor in
+            guard descriptor.kind == .chat,
+                  let candidateId = descriptor.chatSessionId else { return false }
+            return environment.projectList.sessions.contains { candidate in
+                candidate.serverId == session.serverId
+                    && candidate.id == candidateId
+                    && !candidate.isArchived
+            }
+        }?.chatSessionId
     }
 
     /// A chat pane's content: the referenced session's chat, or (for a

--- a/apps/macos/Codevisor/Features/Session/SessionContainerView.swift
+++ b/apps/macos/Codevisor/Features/Session/SessionContainerView.swift
@@ -22,6 +22,9 @@ struct SessionContainerView: View {
     @Environment(\.theme) private var theme
     @Environment(AdaptivePanelLayout.self) private var panelLayout
     @State private var controller: SessionController?
+    /// Global geometry + pointer state for rearranging split leaves inside
+    /// the selected top tab by dragging their headers.
+    @State private var splitDragCoordinator = WorkspaceSplitDragCoordinator()
     /// The session's focus coordinator (composer ⇄ terminals). Owned here so
     /// every center leaf's chat content — any group can host chats — wires
     /// against the same instance.
@@ -140,6 +143,21 @@ struct SessionContainerView: View {
             syncWorkspaceBackgroundTerminals()
         }
         .task(id: session.id) {
+            splitDragCoordinator.canResolve = { sourceLeafId, resolution, canvasSize in
+                canMoveSplitLeaf(
+                    sourceLeafId,
+                    relativeTo: resolution.targetLeafId,
+                    edge: resolution.edge,
+                    canvasSize: canvasSize
+                )
+            }
+            splitDragCoordinator.onResolve = { sourceLeafId, resolution in
+                moveSplitLeaf(
+                    sourceLeafId,
+                    relativeTo: resolution.targetLeafId,
+                    edge: resolution.edge
+                )
+            }
             // Lifecycle hooks (draft cleanup, dissolution) attach to the
             // primary leaf up front; other leaves get them on first access.
             // The ROUTED chat's leaf starts as the ACTIVE group, with the
@@ -272,6 +290,7 @@ struct SessionContainerView: View {
                         centerLeafModel: { leafId in configuredCenterModel(leafId: leafId) },
                         centerPaneTitle: paneTitle,
                         sessionStore: store,
+                        splitDragCoordinator: splitDragCoordinator,
                         onSplitLeaf: splitLeaf,
                         onRenameLeaf: renameLeaf,
                         onCloseLeaf: closeLeaf,
@@ -514,6 +533,71 @@ struct SessionContainerView: View {
         workspaceRevision += 1
         liveCenterTree = workspace.centerTabs[tabIndex].root
         activateLeaf(newLeafId)
+    }
+
+    /// Atomically relocates one whole leaf inside the selected top tab. The
+    /// group id survives, so its cached model and any live terminal surface
+    /// move with the layout instead of being torn down and recreated.
+    private func moveSplitLeaf(_ sourceLeafId: UUID, relativeTo targetLeafId: UUID, edge: SplitEdge) {
+        var workspace = store.workspace(for: session, project: project)
+        guard let tabIndex = workspace.selectedCenterTabIndex else { return }
+        let current = workspace.centerTabs[tabIndex].root
+        guard current.group(id: sourceLeafId) != nil,
+              current.group(id: targetLeafId) != nil else { return }
+
+        let moved = current.movingGroup(
+            id: sourceLeafId,
+            relativeTo: targetLeafId,
+            edge: edge
+        )
+        guard moved != current else { return }
+
+        workspace.centerTabs[tabIndex].root = moved
+        workspace.centerTabs[tabIndex].activeLeafId = sourceLeafId
+        environment.workspaces.save(workspace)
+        workspaceRevision += 1
+        liveCenterTree = moved
+        activateLeaf(sourceLeafId)
+
+        DispatchQueue.main.async {
+            configuredCenterModel(leafId: sourceLeafId).focusSelectedPane()
+        }
+    }
+
+    /// Validates the POST-move topology. A same-row reorder can be valid even
+    /// when the hovered leaf itself is too narrow to halve before the source
+    /// is removed; evaluating the candidate avoids hiding those targets.
+    private func canMoveSplitLeaf(
+        _ sourceLeafId: UUID,
+        relativeTo targetLeafId: UUID,
+        edge: SplitEdge,
+        canvasSize: CGSize
+    ) -> Bool {
+        let workspace = store.workspace(for: session, project: project)
+        guard let current = workspace.selectedCenterTab?.root,
+              canvasSize.width > 0,
+              canvasSize.height > 0 else { return false }
+        let candidate = current.movingGroup(
+            id: sourceLeafId,
+            relativeTo: targetLeafId,
+            edge: edge
+        )
+        guard candidate != current else { return false }
+
+        let currentFrames = normalizedLeafFrames(current).values
+        let candidateFrames = normalizedLeafFrames(candidate).values
+        guard let currentMinWidth = currentFrames.map({ $0.width * canvasSize.width }).min(),
+              let currentMinHeight = currentFrames.map({ $0.height * canvasSize.height }).min()
+        else { return false }
+
+        // A window may already be smaller than the nominal pane floor. In
+        // that case permit moves that do not make its smallest pane worse.
+        let requiredWidth = min(WorkspaceSplitDragCoordinator.minChildWidth, currentMinWidth)
+        let requiredHeight = min(WorkspaceSplitDragCoordinator.minChildHeight, currentMinHeight)
+        return candidateFrames.allSatisfy { frame in
+            frame.width * canvasSize.width >= requiredWidth - 1
+                && frame.height * canvasSize.height >= requiredHeight - 1
+        }
     }
 
     private func closeActiveLeaf() {

--- a/apps/macos/Codevisor/Features/Session/SessionStore.swift
+++ b/apps/macos/Codevisor/Features/Session/SessionStore.swift
@@ -287,7 +287,9 @@ final class SessionStore {
     /// duplicate instances would clobber each other's saves).
     func centerPaneGroup(for session: ChatSession, project: Project) -> PaneGroupModel {
         let workspace = workspace(for: session, project: project)
-        guard let leafId = workspace.centerTree.groupId(containingChat: session.id)
+        guard let leafId = workspace.centerTabs.lazy.compactMap({
+            $0.root.groupId(containingChat: session.id)
+        }).first
             ?? workspace.centerTree.allGroups.first?.id else {
             // Unreachable (a workspace always has a leaf); satisfies the
             // optional without a second cache.
@@ -347,7 +349,9 @@ final class SessionStore {
         // session's chat.
         let workspace = workspace(for: session, project: project)
         let resolvedLeafId = placement == .center
-            ? (leafId ?? workspace.centerTree.groupId(containingChat: session.id))
+            ? (leafId ?? workspace.centerTabs.lazy.compactMap {
+                $0.root.groupId(containingChat: session.id)
+            }.first)
             : nil
         let repository = WorkspacePaneGroupRepository(
             workspaceId: workspace.id,

--- a/apps/macos/Codevisor/Features/Session/SessionView.swift
+++ b/apps/macos/Codevisor/Features/Session/SessionView.swift
@@ -4,8 +4,8 @@ import ACPKit
 
 /// The active session screen: hosts the center pane group (the chat pane —
 /// see ChatScreen — plus any terminals beside it) over the ⌘J bottom panel,
-/// and owns the wiring both share: focus routing, cross-group tab drags, and
-/// the attachment store/drop target.
+/// and owns the wiring both share: focus routing and the attachment
+/// store/drop target.
 struct SessionScreen: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var controller: SessionController
@@ -15,9 +15,6 @@ struct SessionScreen: View {
     /// dropped) beside it. Always visible — it IS the page content. Its tab
     /// strip is hosted by the container in the window's top bar.
     var centerGroup: PaneGroupModel
-    /// Cross-group tab dragging between the top-bar strip and the bottom
-    /// panel; owned by the container (which hosts the top-bar strip).
-    var dragCoordinator: PaneTabDragCoordinator
     /// The session's focus coordinator. Owned by the container (which also
     /// wires every center leaf's chat content with it); previews get their
     /// own.
@@ -26,12 +23,15 @@ struct SessionScreen: View {
     /// keep previews on the single-group path).
     var centerTree: SplitNode? = nil
     var primaryLeafId: UUID? = nil
-    /// The ACTIVE group (keyboard target); its bar shows the ⌘-hints.
+    /// The active split leaf (keyboard target).
     var activeLeafId: UUID? = nil
     var centerLeafModel: ((UUID) -> PaneGroupModel)? = nil
-    var chatTitleLookup: ((PaneDescriptorState) -> String)? = nil
-    /// Diverged-directory badge for tabs (worktree name when a pane runs
-    /// outside the workspace root); nil lookup = no badges.
+    var centerPaneTitle: ((PaneDescriptorState) -> String)? = nil
+    var sessionStore: SessionStore? = nil
+    var onSplitLeaf: ((UUID, SplitEdge) -> Void)? = nil
+    var onRenameLeaf: ((UUID, String) -> Void)? = nil
+    var onCloseLeaf: ((UUID) -> Void)? = nil
+    /// Diverged-directory badge for bottom-panel tabs.
     var paneWorktreeLookup: ((PaneDescriptorState) -> String?)? = nil
     var onCenterTreeChanged: ((SplitNode) -> Void)? = nil
     /// Streamed on every frame of a divider drag (render only) so the
@@ -50,7 +50,7 @@ struct SessionScreen: View {
                 VStack(spacing: 0) {
                     PaneGroupBar(
                         group: paneGroup,
-                        dragCoordinator: dragCoordinator,
+                        dragCoordinator: nil,
                         paneWorktree: paneWorktreeLookup,
                         // The bottom bar is the shortcuts' target while one
                         // of its terminals holds keyboard focus.
@@ -63,11 +63,6 @@ struct SessionScreen: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }
-        // The floating tab that follows the pointer while a tab is dragged
-        // between the two bars (each bar clips its own tabs, so the traveling
-        // tab is drawn up here above everything — extending into the top bar,
-        // where the center strip lives).
-        .overlay { dragGhostOverlay.ignoresSafeArea(edges: .top) }
         // Anchors the focus controller's key-command guard (⌘T/⌘W/⌘1-9) to
         // this window — the composer's window can't serve: it unmounts with
         // the chat tab whenever a terminal or New tab page is selected.
@@ -125,10 +120,8 @@ struct SessionScreen: View {
         .attachmentDropTarget(controller)
     }
 
-    /// The center area: the workspace's split tree — every leaf group
-    /// renders its own tab bar over its content (the Finder model: tabs are
-    /// a content band below the native toolbar). A single-group workspace is
-    /// just the tree's lone leaf.
+    /// The center area: one top-level workspace tab's content-only split
+    /// tree. A single-pane tab is just the tree's lone leaf.
     private var centerContent: some View {
         Group {
             if let centerTree, let centerLeafModel {
@@ -136,14 +129,11 @@ struct SessionScreen: View {
                     node: centerTree,
                     activeLeafId: activeLeafId ?? primaryLeafId,
                     groupModel: centerLeafModel,
-                    chatTitle: chatTitleLookup ?? { $0.name },
-                    paneWorktree: paneWorktreeLookup ?? { _ in nil },
-                    dragCoordinator: dragCoordinator,
-                    showsShortcutHints: { leafId in
-                        // The ACTIVE group is the tab shortcuts' target
-                        // while no bottom-panel pane holds focus.
-                        leafId == (activeLeafId ?? primaryLeafId) && !paneGroup.hasFocusedPane
-                    },
+                    paneTitle: centerPaneTitle ?? { $0.name },
+                    sessionStore: sessionStore,
+                    onSplitLeaf: { leafId, edge in onSplitLeaf?(leafId, edge) },
+                    onRenameLeaf: { leafId, name in onRenameLeaf?(leafId, name) },
+                    onCloseLeaf: { leafId in onCloseLeaf?(leafId) },
                     onTreeChanged: { onCenterTreeChanged?($0) },
                     onLiveTreeChanged: { onCenterTreeLiveChanged?($0) }
                 )
@@ -153,21 +143,6 @@ struct SessionScreen: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    /// See `PaneTabDragGhost`: the tab replica riding the pointer during a
-    /// cross-group drag.
-    private var dragGhostOverlay: some View {
-        GeometryReader { proxy in
-            if let drag = dragCoordinator.active {
-                PaneTabDragGhost(name: drag.name, kind: drag.kind, isAgentOwned: drag.isAgentOwned)
-                    .position(
-                        x: drag.location.x - proxy.frame(in: .global).minX,
-                        y: drag.location.y - proxy.frame(in: .global).minY
-                    )
-            }
-        }
-        .allowsHitTesting(false)
     }
 
     /// Toggles the pane group's content and moves keyboard focus to match
@@ -185,7 +160,6 @@ struct SessionScreen: View {
         controller: .preview(model: .preview()),
         paneGroup: previewPaneGroup(placement: .bottom),
         centerGroup: previewPaneGroup(placement: .center),
-        dragCoordinator: PaneTabDragCoordinator()
     )
     .frame(width: 900, height: 680)
 }
@@ -197,7 +171,6 @@ struct SessionScreen: View {
         controller: .preview(model: .preview()),
         paneGroup: group,
         centerGroup: previewPaneGroup(placement: .center),
-        dragCoordinator: PaneTabDragCoordinator()
     )
     .frame(width: 900, height: 680)
 }

--- a/apps/macos/Codevisor/Features/Session/SessionView.swift
+++ b/apps/macos/Codevisor/Features/Session/SessionView.swift
@@ -28,6 +28,7 @@ struct SessionScreen: View {
     var centerLeafModel: ((UUID) -> PaneGroupModel)? = nil
     var centerPaneTitle: ((PaneDescriptorState) -> String)? = nil
     var sessionStore: SessionStore? = nil
+    var splitDragCoordinator: WorkspaceSplitDragCoordinator? = nil
     var onSplitLeaf: ((UUID, SplitEdge) -> Void)? = nil
     var onRenameLeaf: ((UUID, String) -> Void)? = nil
     var onCloseLeaf: ((UUID) -> Void)? = nil
@@ -115,6 +116,7 @@ struct SessionScreen: View {
         }
         .onDisappear {
             focus.stopTypeToFocus()
+            splitDragCoordinator?.dragCancelled()
         }
         .environment(\.attachmentImages, attachmentImages)
         .attachmentDropTarget(controller)
@@ -131,6 +133,7 @@ struct SessionScreen: View {
                     groupModel: centerLeafModel,
                     paneTitle: centerPaneTitle ?? { $0.name },
                     sessionStore: sessionStore,
+                    dragCoordinator: splitDragCoordinator,
                     onSplitLeaf: { leafId, edge in onSplitLeaf?(leafId, edge) },
                     onRenameLeaf: { leafId, name in onRenameLeaf?(leafId, name) },
                     onCloseLeaf: { leafId in onCloseLeaf?(leafId) },

--- a/apps/macos/Codevisor/Features/Sidebar/SidebarView.swift
+++ b/apps/macos/Codevisor/Features/Sidebar/SidebarView.swift
@@ -1177,17 +1177,7 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func sessionLeadingIcon(_ session: ChatSession) -> some View {
-        if store?.hasUnreadError(session) == true {
-            ErrorUnreadBadge(color: theme.statusError)
-        } else if store?.isWaitingOnUser(session) == true {
-            ActionRequiredIndicator(color: theme.statusError)
-        } else if store?.isRunning(session) == true {
-            AgentActivityIndicator()
-        } else if unreadCount(for: session) != nil {
-            UnreadBadge(color: notificationColor)
-        } else {
-            HarnessIcon(harnessId: session.harnessId, fallbackSymbolName: "bubble.left.fill")
-        }
+        ChatSessionLeadingIcon(session: session, store: store)
     }
 
     @ViewBuilder
@@ -1417,7 +1407,7 @@ struct SidebarView: View {
 
 /// Herdr-inspired working glyph: its ten braille frames advance at roughly
 /// eight steps per second in the harness icon's slot and foreground.
-private struct AgentActivityIndicator: View {
+struct AgentActivityIndicator: View {
     private static let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -1534,7 +1524,7 @@ private struct SessionDropDelegate: DropDelegate {
 }
 
 /// A count-less notification badge for chats that changed while unopened.
-private struct UnreadBadge: View {
+struct UnreadBadge: View {
     let color: Color
 
     var body: some View {
@@ -1546,7 +1536,7 @@ private struct UnreadBadge: View {
 }
 
 /// Higher-priority unread marker for an activity epoch that ended abnormally.
-private struct ErrorUnreadBadge: View {
+struct ErrorUnreadBadge: View {
     let color: Color
 
     var body: some View {
@@ -1559,7 +1549,7 @@ private struct ErrorUnreadBadge: View {
 }
 
 /// Attention marker for a chat blocked on a question or plan approval.
-private struct ActionRequiredIndicator: View {
+struct ActionRequiredIndicator: View {
     let color: Color
 
     var body: some View {

--- a/apps/macos/Codevisor/Features/Terminal/GhosttyTerminalSurfaceAdapter.swift
+++ b/apps/macos/Codevisor/Features/Terminal/GhosttyTerminalSurfaceAdapter.swift
@@ -67,9 +67,8 @@ private final class CodevisorGhosttySurfaceView: Ghostty.SurfaceView {
         window?.makeFirstResponder(self)
     }
 
-    /// Pane-group shortcuts, captured only while this surface has keyboard
-    /// focus: ⌘⌥←/→ navigate tabs, ⌘T opens a new terminal tab. Everything
-    /// else falls through to Ghostty's key handling. The guard is the actual
+    /// Workspace shortcuts, captured only while this surface has keyboard
+    /// focus. Everything else falls through to Ghostty's key handling. The guard is the actual
     /// first-responder relationship — not the published `focused` flag, which
     /// can go stale and would eat composer/menu key equivalents.
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -81,17 +80,53 @@ private final class CodevisorGhosttySurfaceView: Ghostty.SurfaceView {
                 .subtracting([.function, .numericPad])
             if mods == [.command, .option] {
                 if event.specialKey == .leftArrow {
-                    onPaneCommand(.previousTab)
+                    onPaneCommand(.focusSplit(.leading))
                     return true
                 }
                 if event.specialKey == .rightArrow {
+                    onPaneCommand(.focusSplit(.trailing))
+                    return true
+                }
+                if event.specialKey == .upArrow {
+                    onPaneCommand(.focusSplit(.top))
+                    return true
+                }
+                if event.specialKey == .downArrow {
+                    onPaneCommand(.focusSplit(.bottom))
+                    return true
+                }
+            }
+            if mods == [.command, .shift], let chars = event.charactersIgnoringModifiers?.lowercased() {
+                // AppKit preserves Shift in charactersIgnoringModifiers for
+                // punctuation, yielding braces for the bracket keys.
+                if chars == "[" || chars == "{" {
+                    onPaneCommand(.previousTab)
+                    return true
+                }
+                if chars == "]" || chars == "}" {
                     onPaneCommand(.nextTab)
+                    return true
+                }
+                if chars == "d" {
+                    onPaneCommand(.split(.bottom))
                     return true
                 }
             }
             if mods == .command, let chars = event.charactersIgnoringModifiers?.lowercased() {
+                if chars == "[" {
+                    onPaneCommand(.previousSplit)
+                    return true
+                }
+                if chars == "]" {
+                    onPaneCommand(.nextSplit)
+                    return true
+                }
                 if chars == "t" {
                     onPaneCommand(.newTab)
+                    return true
+                }
+                if chars == "d" {
+                    onPaneCommand(.split(.trailing))
                     return true
                 }
                 // ⌘J toggles the panel. Handled here rather than relying on

--- a/apps/macos/Codevisor/Features/Terminal/TerminalFocus.swift
+++ b/apps/macos/Codevisor/Features/Terminal/TerminalFocus.swift
@@ -97,17 +97,9 @@ final class TerminalFocusController {
     /// The session screen's panel toggle (it owns the open/close + focus
     /// handoff); group models across all split leaves relay ⌘J here.
     var requestPanelToggle: (() -> Void)?
-    /// The session's center pane group: tab commands (⌘T/⌘W/⌘1-9/⌘⌥←→)
-    /// pressed while the chat has focus act on it, mirroring how a focused
-    /// terminal routes the same shortcuts to its own group.
+    /// The active center split: workspace tab/split commands pressed while
+    /// the chat has focus route through its model to the container.
     weak var centerGroup: PaneGroupModel?
-    /// Whether the workspace has center tabs beyond the selected one (any
-    /// group). Wired by the container against repository truth. ⌘W is
-    /// CLAIMED while this is true even when the selected tab can't close
-    /// (the anchoring chat) — falling through to Close Window with tabs
-    /// still open is catastrophic; the window only becomes ⌘W's target
-    /// once the workspace is down to its last tab.
-    var hasOtherCenterTabs: (() -> Bool)?
     private var typeToFocusMonitor: Any?
 
     func apply(_ target: SessionFocusTarget) {
@@ -328,9 +320,9 @@ final class TerminalFocusController {
         }
     }
 
-    /// Tab commands while the chat (or anything that isn't a terminal) holds
-    /// focus, acting on the center group — the same shortcuts a focused
-    /// terminal routes to its own group via its key-equivalent handler
+    /// Workspace commands while the chat (or anything that isn't a terminal)
+    /// holds focus. Focused terminals route the same shortcuts through their
+    /// active leaf model via its key-equivalent handler
     /// (GhosttyTerminalSurfaceAdapter), whose matching this mirrors.
     private func handleTabCommand(_ event: NSEvent) -> Bool {
         guard let centerGroup,
@@ -349,30 +341,58 @@ final class TerminalFocusController {
             .subtracting([.function, .numericPad])
         if mods == [.command, .option] {
             if event.specialKey == .leftArrow {
-                centerGroup.handleCommand(.previousTab)
+                centerGroup.handleCommand(.focusSplit(.leading))
                 return true
             }
             if event.specialKey == .rightArrow {
+                centerGroup.handleCommand(.focusSplit(.trailing))
+                return true
+            }
+            if event.specialKey == .upArrow {
+                centerGroup.handleCommand(.focusSplit(.top))
+                return true
+            }
+            if event.specialKey == .downArrow {
+                centerGroup.handleCommand(.focusSplit(.bottom))
+                return true
+            }
+        }
+        if mods == [.command, .shift], let chars = event.charactersIgnoringModifiers?.lowercased() {
+            // AppKit preserves Shift in charactersIgnoringModifiers for
+            // punctuation, yielding braces for the bracket keys.
+            if chars == "[" || chars == "{" {
+                centerGroup.handleCommand(.previousTab)
+                return true
+            }
+            if chars == "]" || chars == "}" {
                 centerGroup.handleCommand(.nextTab)
+                return true
+            }
+            if chars == "d" {
+                centerGroup.handleCommand(.split(.bottom))
                 return true
             }
         }
         if mods == .command, let chars = event.charactersIgnoringModifiers?.lowercased() {
+            if chars == "[" {
+                centerGroup.handleCommand(.previousSplit)
+                return true
+            }
+            if chars == "]" {
+                centerGroup.handleCommand(.nextSplit)
+                return true
+            }
             if chars == "t" {
                 centerGroup.handleCommand(.newTab)
                 return true
             }
+            if chars == "d" {
+                centerGroup.handleCommand(.split(.trailing))
+                return true
+            }
             if chars == "w" {
-                if let selected = centerGroup.state.selectedPane,
-                   centerGroup.canClose(id: selected.id) {
-                    centerGroup.handleCommand(.closeTab)
-                    return true
-                }
-                // The selected tab can't close (the anchoring chat) — but
-                // while OTHER tabs are open anywhere in the workspace, ⌘W
-                // must not fall through to Close Window; it just no-ops.
-                // Only on the last tab does ⌘W become the window's.
-                return hasOtherCenterTabs?() ?? false
+                centerGroup.handleCommand(.closeTab)
+                return true
             }
             if chars.count == 1, let digit = Int(chars), (1...9).contains(digit) {
                 centerGroup.handleCommand(.selectTab(digit - 1))

--- a/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Panes/SplitTree.swift
+++ b/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Panes/SplitTree.swift
@@ -167,6 +167,25 @@ extension SplitNode {
         }
     }
 
+    /// Moves an existing leaf beside another leaf while preserving the
+    /// source group's identity and state. Its old siblings absorb its share;
+    /// the target then splits exactly as it would for a newly-created group.
+    /// Invalid and self-targeted moves are no-ops.
+    public func movingGroup(id sourceId: UUID, relativeTo targetId: UUID, edge: SplitEdge) -> SplitNode {
+        guard sourceId != targetId,
+              let sourceState = group(id: sourceId),
+              group(id: targetId) != nil,
+              let withoutSource = removingGroup(id: sourceId)
+        else { return self }
+
+        return withoutSource.splitting(
+            groupId: targetId,
+            edge: edge,
+            newGroupId: sourceId,
+            newGroupState: sourceState
+        )
+    }
+
     /// The tree with every EMPTY group removed (siblings absorb shares,
     /// single-child splits collapse); nil when no group holds a pane.
     /// Load-time healing: a group is only ever legitimately empty for the

--- a/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Panes/Workspace.swift
+++ b/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Panes/Workspace.swift
@@ -1,11 +1,41 @@
 //  A workspace: the persistence root for everything in a window's content
-//  area. It owns the center split tree (whose leaves are tabbed pane groups —
-//  chats, terminals, and later diff viewers/previews) and the ⌘J bottom
-//  panel. Chats are REFERENCES to sessions (the server owns transcripts and
+//  area. It owns browser-style tabs whose contents are split trees (one pane
+//  per leaf), plus the workspace-wide ⌘J bottom panel. Chats are
+//  REFERENCES to sessions (the server owns transcripts and
 //  lifecycle); a workspace can host many, each anchored to a directory under
 //  the workspace's root.
 
 import Foundation
+
+/// One browser-style workspace tab. Its content is an independent split
+/// layout and `activeLeafId` records which split receives keyboard commands
+/// and supplies the tab's title/icon.
+public struct WorkspaceTab: Codable, Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public var root: SplitNode
+    public var activeLeafId: UUID
+
+    public init(id: UUID = UUID(), root: SplitNode, activeLeafId: UUID? = nil) {
+        self.id = id
+        self.root = root
+        self.activeLeafId = activeLeafId.flatMap { root.group(id: $0) != nil ? $0 : nil }
+            ?? root.allGroups.first?.id
+            ?? UUID()
+    }
+
+    private enum CodingKeys: String, CodingKey { case id, root, activeLeafId }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        let decodedRoot = try container.decode(SplitNode.self, forKey: .root)
+        root = decodedRoot
+        let decoded = try container.decodeIfPresent(UUID.self, forKey: .activeLeafId)
+        activeLeafId = decoded.flatMap { decodedRoot.group(id: $0) != nil ? $0 : nil }
+            ?? decodedRoot.allGroups.first?.id
+            ?? UUID()
+    }
+}
 
 public struct Workspace: Codable, Sendable, Equatable, Identifiable {
     public let id: UUID
@@ -24,8 +54,10 @@ public struct Workspace: Codable, Sendable, Equatable, Identifiable {
     /// The machine the workspace's sessions and shells live on.
     public let serverId: String
     public let projectId: UUID
-    /// The center area's layout: a tree of splits over tabbed groups.
-    public var centerTree: SplitNode
+    /// Browser-style tabs across the center area. Each tab owns a split tree
+    /// whose leaf groups contain exactly one pane.
+    public var centerTabs: [WorkspaceTab]
+    public var selectedCenterTabId: UUID
     /// The ⌘J bottom panel.
     public var bottomGroup: PaneGroupState
     public var createdAt: Date
@@ -37,7 +69,9 @@ public struct Workspace: Codable, Sendable, Equatable, Identifiable {
 
     private enum CodingKeys: String, CodingKey {
         case id, name, hasCustomName, rootDirectory, symbolName, serverId
-        case projectId, centerTree, bottomGroup, createdAt, isArchived
+        case projectId, centerTabs, selectedCenterTabId, bottomGroup, createdAt, isArchived
+        /// Version-1 workspaces stored one tree whose leaves were tab groups.
+        case centerTree
     }
 
     public init(from decoder: Decoder) throws {
@@ -49,10 +83,46 @@ public struct Workspace: Codable, Sendable, Equatable, Identifiable {
         symbolName = try container.decodeIfPresent(String.self, forKey: .symbolName)
         serverId = try container.decode(String.self, forKey: .serverId)
         projectId = try container.decode(UUID.self, forKey: .projectId)
-        centerTree = try container.decode(SplitNode.self, forKey: .centerTree)
+        if let decodedTabs = try container.decodeIfPresent([WorkspaceTab].self, forKey: .centerTabs) {
+            if decodedTabs.isEmpty {
+                var state = PaneGroupState()
+                _ = state.addNewTabPane(inheritedCwd: rootDirectory)
+                let replacement = WorkspaceTab(root: .leaf(state))
+                centerTabs = [replacement]
+                selectedCenterTabId = replacement.id
+            } else {
+                centerTabs = decodedTabs
+                let decodedSelection = try container.decodeIfPresent(
+                    UUID.self, forKey: .selectedCenterTabId
+                )
+                selectedCenterTabId = decodedSelection.flatMap { candidate in
+                    decodedTabs.contains { $0.id == candidate } ? candidate : nil
+                } ?? decodedTabs[0].id
+            }
+        } else {
+            let legacy = try container.decode(SplitNode.self, forKey: .centerTree)
+            centerTabs = Self.migrateLegacyCenterTree(legacy)
+            selectedCenterTabId = centerTabs[0].id
+        }
         bottomGroup = try container.decode(PaneGroupState.self, forKey: .bottomGroup)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(hasCustomName, forKey: .hasCustomName)
+        try container.encodeIfPresent(rootDirectory, forKey: .rootDirectory)
+        try container.encodeIfPresent(symbolName, forKey: .symbolName)
+        try container.encode(serverId, forKey: .serverId)
+        try container.encode(projectId, forKey: .projectId)
+        try container.encode(centerTabs, forKey: .centerTabs)
+        try container.encode(selectedCenterTabId, forKey: .selectedCenterTabId)
+        try container.encode(bottomGroup, forKey: .bottomGroup)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(isArchived, forKey: .isArchived)
     }
 
     public init(
@@ -75,16 +145,120 @@ public struct Workspace: Codable, Sendable, Equatable, Identifiable {
         self.symbolName = symbolName
         self.serverId = serverId
         self.projectId = projectId
-        self.centerTree = centerTree
+        let tabs = Self.migrateLegacyCenterTree(centerTree)
+        self.centerTabs = tabs
+        self.selectedCenterTabId = tabs[0].id
         self.bottomGroup = bottomGroup
         self.createdAt = createdAt
         self.isArchived = isArchived
     }
 
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        hasCustomName: Bool = false,
+        rootDirectory: String?,
+        symbolName: String? = nil,
+        serverId: String,
+        projectId: UUID,
+        centerTabs: [WorkspaceTab],
+        selectedCenterTabId: UUID? = nil,
+        bottomGroup: PaneGroupState,
+        createdAt: Date = Date(),
+        isArchived: Bool = false
+    ) {
+        precondition(!centerTabs.isEmpty, "A workspace must contain at least one center tab")
+        self.id = id
+        self.name = name
+        self.hasCustomName = hasCustomName
+        self.rootDirectory = rootDirectory
+        self.symbolName = symbolName
+        self.serverId = serverId
+        self.projectId = projectId
+        self.centerTabs = centerTabs
+        self.selectedCenterTabId = selectedCenterTabId.flatMap { candidate in
+            centerTabs.contains { $0.id == candidate } ? candidate : nil
+        } ?? centerTabs[0].id
+        self.bottomGroup = bottomGroup
+        self.createdAt = createdAt
+        self.isArchived = isArchived
+    }
+
+    /// Transitional convenience for layout code: reads/writes the selected
+    /// top tab's tree. New code should use `centerTabs` when it needs to see
+    /// across tabs.
+    public var centerTree: SplitNode {
+        get { selectedCenterTab?.root ?? centerTabs[0].root }
+        set {
+            guard let index = selectedCenterTabIndex else { return }
+            centerTabs[index].root = newValue
+            if newValue.group(id: centerTabs[index].activeLeafId) == nil,
+               let first = newValue.allGroups.first?.id {
+                centerTabs[index].activeLeafId = first
+            }
+        }
+    }
+
+    public var selectedCenterTabIndex: Int? {
+        centerTabs.firstIndex { $0.id == selectedCenterTabId }
+    }
+
+    public var selectedCenterTab: WorkspaceTab? {
+        selectedCenterTabIndex.map { centerTabs[$0] }
+    }
+
+    public func tabId(containingPane paneId: UUID) -> UUID? {
+        centerTabs.first { $0.root.groupId(containingPane: paneId) != nil }?.id
+    }
+
+    public func tabId(containingChat sessionId: UUID) -> UUID? {
+        centerTabs.first { $0.root.groupId(containingChat: sessionId) != nil }?.id
+    }
+
     /// Session ids of every chat pane in the workspace, reading order.
     public var chatSessionIds: [UUID] {
-        centerTree.allGroups.flatMap { group in
-            group.state.panes.compactMap { $0.kind == .chat ? $0.chatSessionId : nil }
+        centerTabs.flatMap { tab in
+            tab.root.allGroups.flatMap { group in
+                group.state.panes.compactMap { $0.kind == .chat ? $0.chatSessionId : nil }
+            }
         }
+    }
+
+    /// Inverts the version-1 `split → tab groups` hierarchy. The selected
+    /// pane from every old group keeps the visible split topology; hidden
+    /// siblings become independent top tabs in deterministic reading order.
+    private static func migrateLegacyCenterTree(_ legacy: SplitNode) -> [WorkspaceTab] {
+        var overflow: [PaneDescriptorState] = []
+
+        func selectedOnly(_ node: SplitNode) -> SplitNode {
+            switch node {
+            case let .group(id, state):
+                let selected = state.selectedPane
+                    ?? state.panes.first
+                    ?? PaneDescriptorState(
+                        id: UUID(), kind: .newTab, name: "New Tab", terminalKey: UUID().uuidString
+                    )
+                overflow.append(contentsOf: state.panes.filter { $0.id != selected.id })
+                var single = state
+                single.panes = [selected]
+                single.selectedPaneId = selected.id
+                single.isVisible = true
+                return .group(id: id, state: single)
+            case let .split(orientation, children):
+                return .split(orientation: orientation, children: children.map {
+                    SplitChild(fraction: $0.fraction, node: selectedOnly($0.node))
+                })
+            }
+        }
+
+        let visible = WorkspaceTab(root: selectedOnly(legacy))
+        let lifted = overflow.map { pane -> WorkspaceTab in
+            var state = PaneGroupState()
+            state.panes = [pane]
+            state.selectedPaneId = pane.id
+            state.isVisible = true
+            return WorkspaceTab(root: .leaf(state))
+        }
+        return [visible] + lifted
     }
 }

--- a/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Persistence/WorkspaceRepository.swift
+++ b/apps/macos/Packages/CodevisorCore/Sources/CodevisorCore/Persistence/WorkspaceRepository.swift
@@ -1,7 +1,8 @@
 //  Workspace persistence + the sessions→workspaces backfill.
 //
-//  Workspaces are the persistence root for pane layout (center split tree +
-//  bottom panel). The backfill is incremental and idempotent: "ensure a
+//  Workspaces are the persistence root for pane layout (top tabs containing
+//  center split trees, plus the bottom panel). The backfill is incremental
+//  and idempotent: "ensure a
 //  workspace exists for this session" runs whenever a session is opened, so
 //  existing chats gain owning workspaces lazily per machine as their
 //  sessions load — never touching server-side session data, only
@@ -66,7 +67,7 @@ public final class DefaultWorkspaceRepository: WorkspaceRepository, @unchecked S
         var workspaces: [Workspace]
         var sessionIndex: [UUID: UUID]
 
-        static let empty = Payload(version: 1, workspaces: [], sessionIndex: [:])
+        static let empty = Payload(version: 2, workspaces: [], sessionIndex: [:])
     }
 
     private let store: any PersistenceStore
@@ -179,15 +180,37 @@ public final class DefaultWorkspaceRepository: WorkspaceRepository, @unchecked S
         } else {
             loaded = .empty
         }
-        // Load-time healing: drop empty groups persisted by an interrupted
-        // drop (see `prunedEmptyGroups`). Runs once per launch, before the
-        // cache exists, so it can never race an in-session drop's transient
-        // empty group.
+        let requiresRewrite = loaded.version < 2
+        loaded.version = 2
+        let workspacesBeforeHealing = loaded.workspaces
+        // Load-time healing: prune interrupted empty leaves from every top
+        // tab, drop empty tabs, and repair both selection levels.
         for index in loaded.workspaces.indices {
-            if let pruned = loaded.workspaces[index].centerTree.prunedEmptyGroups,
-               pruned != loaded.workspaces[index].centerTree {
-                loaded.workspaces[index].centerTree = pruned
+            var workspace = loaded.workspaces[index]
+            workspace.centerTabs = workspace.centerTabs.compactMap { tab in
+                guard let pruned = tab.root.prunedEmptyGroups else { return nil }
+                var repaired = tab
+                repaired.root = pruned
+                if pruned.group(id: repaired.activeLeafId) == nil,
+                   let first = pruned.allGroups.first?.id {
+                    repaired.activeLeafId = first
+                }
+                return repaired
             }
+            if workspace.centerTabs.isEmpty {
+                var state = PaneGroupState()
+                _ = state.addNewTabPane()
+                let tab = WorkspaceTab(root: .leaf(state))
+                workspace.centerTabs = [tab]
+                workspace.selectedCenterTabId = tab.id
+            } else if !workspace.centerTabs.contains(where: { $0.id == workspace.selectedCenterTabId }) {
+                workspace.selectedCenterTabId = workspace.centerTabs[0].id
+            }
+            loaded.workspaces[index] = workspace
+        }
+        if (requiresRewrite || loaded.workspaces != workspacesBeforeHealing),
+           let encoded = try? JSONEncoder().encode(loaded) {
+            try? store.saveData(encoded, forKey: key)
         }
         lock.withLock { if cache == nil { cache = loaded } }
         return loaded
@@ -226,7 +249,7 @@ public final class WorkspacePaneGroupRepository: PaneGroupRepository, @unchecked
             return workspace.bottomGroup
         case .center:
             guard let groupId else { return workspace.centerTree.allGroups.first?.state }
-            return workspace.centerTree.group(id: groupId)
+            return workspace.centerTabs.lazy.compactMap { $0.root.group(id: groupId) }.first
         }
     }
 
@@ -238,7 +261,11 @@ public final class WorkspacePaneGroupRepository: PaneGroupRepository, @unchecked
         case .center:
             let targetId = groupId ?? workspace.centerTree.allGroups.first?.id
             guard let targetId else { return }
-            workspace.centerTree = workspace.centerTree.updatingGroup(id: targetId) { _ in state }
+            guard let tabIndex = workspace.centerTabs.firstIndex(where: {
+                $0.root.group(id: targetId) != nil
+            }) else { return }
+            workspace.centerTabs[tabIndex].root = workspace.centerTabs[tabIndex].root
+                .updatingGroup(id: targetId) { _ in state }
         }
         repository.save(workspace)
     }

--- a/apps/macos/Packages/CodevisorCore/Tests/CodevisorCoreTests/WorkspaceTests.swift
+++ b/apps/macos/Packages/CodevisorCore/Tests/CodevisorCoreTests/WorkspaceTests.swift
@@ -123,6 +123,64 @@ struct SplitTreeTests {
         #expect(SplitNode.leaf(groupState(), id: a).removingGroup(id: a) == nil)
     }
 
+    @Test("Moving a group reorders siblings and preserves identity and state")
+    func moveGroupAmongSiblings() {
+        let a = UUID(), b = UUID(), c = UUID()
+        let aState = groupState(2)
+        let tree = SplitNode.split(orientation: .horizontal, children: [
+            SplitChild(fraction: 0.4, node: .leaf(aState, id: a)),
+            SplitChild(fraction: 0.3, node: .leaf(groupState(), id: b)),
+            SplitChild(fraction: 0.3, node: .leaf(groupState(), id: c))
+        ])
+
+        let moved = tree.movingGroup(id: a, relativeTo: b, edge: .trailing)
+
+        #expect(moved.allGroups.map(\.id) == [b, a, c])
+        #expect(moved.group(id: a) == aState)
+        guard case let .split(orientation, children) = moved else {
+            Issue.record("expected horizontal split")
+            return
+        }
+        #expect(orientation == .horizontal)
+        #expect(children.count == 3)
+        #expect(abs(children.map(\.fraction).reduce(0, +) - 1) < 0.0001)
+    }
+
+    @Test("Moving a nested group collapses its old parent and inserts on the target edge")
+    func moveNestedGroup() {
+        let a = UUID(), b = UUID(), c = UUID()
+        let tree = SplitNode.split(orientation: .horizontal, children: [
+            SplitChild(fraction: 0.7, node: .split(orientation: .vertical, children: [
+                SplitChild(fraction: 0.5, node: .leaf(groupState(), id: a)),
+                SplitChild(fraction: 0.5, node: .leaf(groupState(), id: b))
+            ])),
+            SplitChild(fraction: 0.3, node: .leaf(groupState(), id: c))
+        ])
+
+        let moved = tree.movingGroup(id: c, relativeTo: a, edge: .top)
+
+        guard case let .split(orientation, children) = moved else {
+            Issue.record("expected collapsed vertical root")
+            return
+        }
+        #expect(orientation == .vertical)
+        #expect(children.count == 3)
+        #expect(moved.allGroups.map(\.id) == [c, a, b])
+    }
+
+    @Test("Invalid and self-targeted group moves are no-ops")
+    func invalidGroupMoves() {
+        let a = UUID(), b = UUID()
+        let tree = SplitNode.split(orientation: .horizontal, children: [
+            SplitChild(fraction: 0.5, node: .leaf(groupState(), id: a)),
+            SplitChild(fraction: 0.5, node: .leaf(groupState(), id: b))
+        ])
+
+        #expect(tree.movingGroup(id: a, relativeTo: a, edge: .leading) == tree)
+        #expect(tree.movingGroup(id: UUID(), relativeTo: b, edge: .leading) == tree)
+        #expect(tree.movingGroup(id: a, relativeTo: UUID(), edge: .leading) == tree)
+    }
+
     @Test("Pruning removes empty groups and collapses their splits")
     func pruneEmptyGroups() {
         let chat = UUID(), empty = UUID(), terminal = UUID()

--- a/apps/macos/Packages/CodevisorCore/Tests/CodevisorCoreTests/WorkspaceTests.swift
+++ b/apps/macos/Packages/CodevisorCore/Tests/CodevisorCoreTests/WorkspaceTests.swift
@@ -289,12 +289,75 @@ struct WorkspaceRepositoryTests {
             for: seed(sessionId: sessionId),
             legacyGroups: legacy
         )
-        // Chat + terminal in the center leaf; the chat pane learned its
+        // The legacy group's selected terminal remains the visible-layout
+        // tab; its hidden chat is lifted into its own top tab and learns its
         // session reference during migration.
-        let centerGroup = workspace.centerTree.allGroups[0].state
-        #expect(centerGroup.panes.map(\.kind) == [.chat, .terminal])
-        #expect(centerGroup.panes[0].chatSessionId == sessionId)
+        #expect(workspace.centerTabs.count == 2)
+        #expect(workspace.centerTabs.allSatisfy {
+            $0.root.allGroups.allSatisfy { $0.state.panes.count == 1 }
+        })
+        #expect(workspace.chatSessionIds == [sessionId])
         #expect(workspace.bottomGroup.panes.count == 2)
+    }
+
+    @Test("Version-1 split groups invert into layout tabs without losing panes")
+    func legacyWorkspaceInversion() throws {
+        let chatSession = UUID()
+        var left = PaneGroupState.centerInitial(sessionId: chatSession)
+        let selectedTerminal = left.addTerminalPane(sessionId: chatSession)
+        var right = PaneGroupState()
+        let firstRight = right.addTerminalPane(sessionId: chatSession)
+        let selectedRight = right.addTerminalPane(sessionId: chatSession)
+        let leftId = UUID(), rightId = UUID()
+        let legacyTree = SplitNode.split(orientation: .horizontal, children: [
+            SplitChild(fraction: 0.35, node: .leaf(left, id: leftId)),
+            SplitChild(fraction: 0.65, node: .leaf(right, id: rightId))
+        ])
+
+        let fresh = Workspace(
+            name: "Legacy", rootDirectory: "/tmp", serverId: "local", projectId: UUID(),
+            centerTree: .leaf(.centerInitial(sessionId: chatSession)),
+            bottomGroup: .initial(sessionId: chatSession)
+        )
+        var json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(fresh)) as! [String: Any]
+        json.removeValue(forKey: "centerTabs")
+        json.removeValue(forKey: "selectedCenterTabId")
+        json["centerTree"] = try JSONSerialization.jsonObject(with: JSONEncoder().encode(legacyTree))
+
+        let decoded = try JSONDecoder().decode(
+            Workspace.self,
+            from: JSONSerialization.data(withJSONObject: json)
+        )
+        #expect(decoded.centerTabs.count == 3)
+        #expect(decoded.centerTabs[0].root.allGroups.map(\.id) == [leftId, rightId])
+        #expect(decoded.centerTabs[0].root.allGroups.map { $0.state.panes[0].id }
+            == [selectedTerminal.id, selectedRight.id])
+        #expect(decoded.centerTabs[1].root.allGroups[0].state.panes[0].chatSessionId == chatSession)
+        #expect(decoded.centerTabs[2].root.allGroups[0].state.panes[0].id == firstRight.id)
+        #expect(decoded.centerTabs.flatMap { $0.root.allGroups }.allSatisfy {
+            $0.state.panes.count == 1
+        })
+    }
+
+    @Test("A version-2 workspace with no tabs repairs to a New Tab page")
+    func emptyTopTabsRepairOnDecode() throws {
+        let fresh = Workspace(
+            name: "Empty", rootDirectory: "/tmp/project", serverId: "local",
+            projectId: UUID(), centerTree: .leaf(.centerInitial(sessionId: UUID())),
+            bottomGroup: .initial(sessionId: UUID())
+        )
+        var json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(fresh)) as! [String: Any]
+        json["centerTabs"] = []
+        json["selectedCenterTabId"] = UUID().uuidString
+
+        let decoded = try JSONDecoder().decode(
+            Workspace.self,
+            from: JSONSerialization.data(withJSONObject: json)
+        )
+        #expect(decoded.centerTabs.count == 1)
+        #expect(decoded.selectedCenterTabId == decoded.centerTabs[0].id)
+        #expect(decoded.centerTabs[0].root.allGroups[0].state.selectedPane?.kind == .newTab)
+        #expect(decoded.centerTabs[0].root.allGroups[0].state.selectedPane?.cwdOverride == "/tmp/project")
     }
 
     @Test("Automatic names follow new worktrees but explicit names stay pinned")
@@ -338,10 +401,10 @@ struct WorkspaceRepositoryTests {
 
         var center = bridge.load(sessionId: sessionId, placement: .center)
         #expect(center?.panes.first?.kind == .chat)
-        center?.addTerminalPane(sessionId: sessionId)
+        center?.panes[0].name = "Renamed Chat"
         bridge.save(center!, sessionId: sessionId, placement: .center)
-        #expect(bridge.load(sessionId: sessionId, placement: .center)?.panes.count == 2)
-        #expect(repository.workspace(id: workspace.id)?.centerTree.allGroups[0].state.panes.count == 2)
+        #expect(bridge.load(sessionId: sessionId, placement: .center)?.panes[0].name == "Renamed Chat")
+        #expect(repository.workspace(id: workspace.id)?.centerTree.allGroups[0].state.panes.count == 1)
 
         var bottom = bridge.load(sessionId: sessionId, placement: .bottom)!
         bottom.setHeight(300)


### PR DESCRIPTION
## Summary

- invert the workspace model so top-level tabs each own a persistent split tree
- restore the existing browser-style tab UI and add split headers with pane actions, dynamic chat status icons, and unified inactive dimming
- add tab/split keyboard navigation, including reliable shortcuts while Ghostty terminals are focused
- migrate legacy workspace layouts and cover the new persistence model with tests

## Validation

- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path apps/macos/Packages (435 CodevisorCore/StreamMarkdown tests plus package suites passed)
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project apps/macos/Codevisor.xcodeproj -scheme Codevisor -configuration Debug -derivedDataPath tmp/DerivedData build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/851-labs/codesmith/codevisor/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787269910&installation_model_id=428386&pr_number=5&repository=851-labs%2Fcodevisor&return_to=https%3A%2F%2Fgithub.com%2F851-labs%2Fcodevisor%2Fpull%2F5&signature=7f0c52c2eb01fa86cc19d412eb58a57af6ad8e2bbfc3796a8d949966048cb2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->